### PR TITLE
add qpid connection heartbeat to mitigate network packet loss.

### DIFF
--- a/src/gofer/transport/qpid/broker.py
+++ b/src/gofer/transport/qpid/broker.py
@@ -72,6 +72,7 @@ class Qpid(Broker):
                 port=self.port,
                 tcp_nodelay=True,
                 reconnect=True,
+                heartbeat=10,
                 transport=self.transport,
                 username=self.userid,
                 password=self.password,


### PR DESCRIPTION
Enable qpid connection heartbeat to mitigate network packet loss.

Back port from 2.4.