### PR TITLE
Larger pending queue depth.

### DIFF
--- a/docs/sphinx/configuration.rst
+++ b/docs/sphinx/configuration.rst
@@ -129,6 +129,11 @@ Defines basic plugin properties.
 
 File extensions just be (.conf|.json).
 
+[pending]
+
+- **depth** - The pending queue depth.  Default: 100K
+
+
 [model]
 -------
 

--- a/src/gofer/agent/config.py
+++ b/src/gofer/agent/config.py
@@ -84,6 +84,11 @@ AGENT_SCHEMA = (
 #   authenticator
 #      The (optional) fully qualified Authenticator to be loaded from the PYTHON path.
 #
+# [pending]
+#
+#   depth
+#     The pending queue depth.  Default: 100K
+#
 # [model]
 #
 #   managed
@@ -121,6 +126,11 @@ PLUGIN_SCHEMA = (
             ('heartbeat', OPTIONAL, NUMBER),
         )
     ),
+    ('pending', OPTIONAL,
+        (
+            ('depth', REQUIRED, NUMBER),
+        )
+    ),
     ('model', OPTIONAL,
         (
             ('managed', OPTIONAL, '(0|1|2)'),
@@ -154,6 +164,9 @@ PLUGIN_DEFAULTS = {
     },
     'messaging': {
         'heartbeat': '10'
+    },
+    'pending': {
+        'depth': '100000'
     },
     'model': {
         'managed': '2'

--- a/src/gofer/agent/plugin.py
+++ b/src/gofer/agent/plugin.py
@@ -248,7 +248,7 @@ class Plugin(object):
         self.actions = []
         self.dispatcher = Dispatcher()
         self.whiteboard = Whiteboard()
-        self.scheduler = Scheduler(self)
+        self.scheduler = Scheduler(self, int(descriptor.pending.depth))
         self.delegate = Delegate()
         self.authenticator = None
         self.consumer = None

--- a/src/gofer/agent/rmi.py
+++ b/src/gofer/agent/rmi.py
@@ -146,14 +146,16 @@ class Scheduler(Thread):
     Processes the *pending* queue.
     """
     
-    def __init__(self, plugin):
+    def __init__(self, plugin, depth):
         """
         :param plugin: A plugin.
         :type plugin: gofer.agent.plugin.Plugin
+        :param depth: The max queue depth.
+        :type depth: int
         """
         Thread.__init__(self, name='scheduler:%s' % plugin.name)
         self.plugin = plugin
-        self.pending = Pending(plugin.name)
+        self.pending = Pending(plugin.name, depth)
         self.builtin = Builtin(plugin)
         self.setDaemon(True)
 

--- a/test/functional/plugins/testplugin.conf
+++ b/test/functional/plugins/testplugin.conf
@@ -27,6 +27,11 @@
 #   host_validation
 #      The (optional) flag indicates SSL host validation should be performed.
 #
+# [pending]
+#
+#   depth
+#      The pending queue depth.  Default: 100K
+#
 # [model]
 #
 #   managed
@@ -46,6 +51,9 @@
 [main]
 enabled=1
 forward=*
+
+[pending]
+depth=500
 
 [messaging]
 uuid=TEST

--- a/test/unit/agent/test_plugin.py
+++ b/test/unit/agent/test_plugin.py
@@ -121,7 +121,8 @@ class TestPlugin(TestCase):
     @patch('gofer.agent.plugin.ThreadPool')
     def test_init(self, pool, dispatcher, whiteboard, scheduler, delegate):
         threads = 4
-        descriptor = Mock(main=Mock(threads=threads))
+        depth = 1234
+        descriptor = Mock(main=Mock(threads=threads), pending=Mock(depth=depth))
         path = '/tmp/path'
 
         # test
@@ -130,7 +131,7 @@ class TestPlugin(TestCase):
         # validation
         pool.assert_called_once_with(threads)
         dispatcher.assert_called_once_with()
-        scheduler.assert_called_once_with(plugin)
+        scheduler.assert_called_once_with(plugin, depth)
         delegate.assert_called_once_with()
         self.assertEqual(plugin.descriptor, descriptor)
         self.assertEqual(plugin.path, path)
@@ -156,6 +157,8 @@ class TestPlugin(TestCase):
                 threads=4,
                 forward='a, b, c',
                 accept='d, e, f'),
+            pending=Mock(
+                depth=1234),
             messaging=Mock(
                 uuid='x99',
                 url='amqp://localhost')
@@ -195,7 +198,7 @@ class TestPlugin(TestCase):
     @patch('gofer.agent.plugin.Whiteboard', Mock())
     @patch('gofer.agent.plugin.ThreadPool', Mock())
     def test_start(self, scheduler):
-        descriptor = Mock(main=Mock(threads=4))
+        descriptor = Mock(main=Mock(threads=4), pending=Mock(depth=1234))
         scheduler.return_value.isAlive.return_value = False
 
         # test
@@ -211,7 +214,7 @@ class TestPlugin(TestCase):
     @patch('gofer.agent.plugin.Whiteboard', Mock())
     @patch('gofer.agent.plugin.ThreadPool', Mock())
     def test_start_already_started(self, scheduler):
-        descriptor = Mock(main=Mock(threads=4))
+        descriptor = Mock(main=Mock(threads=4), pending=Mock(depth=1234))
         scheduler.return_value.isAlive.return_value = True
 
         # test
@@ -227,7 +230,7 @@ class TestPlugin(TestCase):
     @patch('gofer.agent.plugin.ThreadPool')
     @patch('gofer.agent.plugin.Whiteboard', Mock())
     def test_shutdown(self, pool, scheduler):
-        descriptor = Mock(main=Mock(threads=4))
+        descriptor = Mock(main=Mock(threads=4), pending=Mock(depth=1234))
         scheduler.return_value.isAlive.return_value = True
 
         # test
@@ -245,7 +248,7 @@ class TestPlugin(TestCase):
     @patch('gofer.agent.plugin.ThreadPool')
     @patch('gofer.agent.plugin.Whiteboard', Mock())
     def test_shutdown_not_running(self, pool, scheduler):
-        descriptor = Mock(main=Mock(threads=4))
+        descriptor = Mock(main=Mock(threads=4), pending=Mock(depth=1234))
         scheduler.return_value.isAlive.return_value = False
 
         # test
@@ -269,6 +272,8 @@ class TestPlugin(TestCase):
             main=Mock(
                 enabled='1',
                 threads=4),
+            pending=Mock(
+                depth=1234),
             messaging=Mock(
                 uuid='x99',
                 url='amqp://localhost',
@@ -299,7 +304,7 @@ class TestPlugin(TestCase):
     @patch('gofer.agent.plugin.Whiteboard', Mock())
     def test_attach(self, pool, model, consumer, node):
         queue = 'test'
-        descriptor = Mock(main=Mock(threads=4))
+        descriptor = Mock(main=Mock(threads=4), pending=Mock(depth=1234))
         pool.return_value.run.side_effect = lambda fn: fn()
         model.return_value.queue = queue
 
@@ -326,7 +331,7 @@ class TestPlugin(TestCase):
     @patch('gofer.agent.plugin.Scheduler', Mock())
     @patch('gofer.agent.plugin.Whiteboard', Mock())
     def test_detach(self, model):
-        descriptor = Mock(main=Mock(threads=4))
+        descriptor = Mock(main=Mock(threads=4), pending=Mock(depth=1234))
         consumer = Mock()
 
         # test
@@ -347,7 +352,7 @@ class TestPlugin(TestCase):
     @patch('gofer.agent.plugin.Scheduler', Mock())
     @patch('gofer.agent.plugin.Whiteboard', Mock())
     def test_detach_not_attached(self, model):
-        descriptor = Mock(main=Mock(threads=4))
+        descriptor = Mock(main=Mock(threads=4), pending=Mock(depth=1234))
 
         # test
         plugin = Plugin(descriptor, '')
@@ -361,7 +366,7 @@ class TestPlugin(TestCase):
     @patch('gofer.agent.plugin.Scheduler', Mock())
     @patch('gofer.agent.plugin.Whiteboard', Mock())
     def test_detach_no_teardown(self, model):
-        descriptor = Mock(main=Mock(threads=4))
+        descriptor = Mock(main=Mock(threads=4), pending=Mock(depth=1234))
         consumer = Mock()
 
         # test
@@ -379,7 +384,7 @@ class TestPlugin(TestCase):
     @patch('gofer.agent.plugin.Scheduler', Mock())
     @patch('gofer.agent.plugin.Whiteboard', Mock())
     def test_provides(self):
-        descriptor = Mock(main=Mock(threads=4))
+        descriptor = Mock(main=Mock(threads=4), pending=Mock(depth=1234))
 
         # test
         plugin = Plugin(descriptor, '')

--- a/test/unit/agent/test_rmi.py
+++ b/test/unit/agent/test_rmi.py
@@ -23,9 +23,10 @@ class TestScheduler(TestCase):
     @patch('gofer.agent.rmi.Pending')
     @patch('gofer.agent.rmi.Builtin')
     def test_init(self, builtin, pending, set_daemon):
+        depth = 1234
         plugin = Mock()
-        scheduler = Scheduler(plugin)
-        pending.assert_called_once_with(plugin.name)
+        scheduler = Scheduler(plugin, depth)
+        pending.assert_called_once_with(plugin.name, depth)
         builtin.assert_called_once_with(plugin)
         set_daemon.assert_called_with(True)
         self.assertEqual(scheduler.plugin, plugin)
@@ -55,7 +56,7 @@ class TestScheduler(TestCase):
         select_plugin.side_effect = [builtin.return_value, plugin]
 
         # test
-        scheduler = Scheduler(plugin)
+        scheduler = Scheduler(plugin, 243)
         scheduler.run()
 
         # validation
@@ -88,7 +89,7 @@ class TestScheduler(TestCase):
         aborted.side_effect = [False, True]
 
         # test
-        scheduler = Scheduler(plugin)
+        scheduler = Scheduler(plugin, 243)
         scheduler.run()
 
         # validation
@@ -100,7 +101,7 @@ class TestScheduler(TestCase):
     def test_select_plugin(self, builtin):
         plugin = Mock()
         request = Document(request={'classname': 'A'})
-        scheduler = Scheduler(plugin)
+        scheduler = Scheduler(plugin, 243)
         # find builtin
         builtin.return_value.provides.return_value = True
         selected = scheduler.select_plugin(request)
@@ -122,7 +123,7 @@ class TestScheduler(TestCase):
     def test_add(self, pending):
         plugin = Mock()
         request = Mock()
-        scheduler = Scheduler(plugin)
+        scheduler = Scheduler(plugin, 243)
         scheduler.add(request)
         pending.return_value.put.assert_called_once_with(request)
 
@@ -132,7 +133,7 @@ class TestScheduler(TestCase):
     @patch('threading.Thread.setDaemon', Mock())
     def test_shutdown(self, abort, builtin):
         plugin = Mock()
-        scheduler = Scheduler(plugin)
+        scheduler = Scheduler(plugin, 243)
         scheduler.shutdown()
         builtin.return_value.shutdown.assert_called_once_with()
         abort.assert_called_once_with()


### PR DESCRIPTION
Larger pending queue depth that is also configurable for each plugin.  The default is: 100k.  The pending queue continues to queue the actual request unless the queue depth exceeds a threshold.  When the threshold is reached, the journal file path is stored instead to minimize the memory footprint.  With a smaller (deterministic) memory footprint for each queued request (path), the depth can be safely be very large.  The default is 100K.