### PR TITLE
[2.6] Larger pending queue depth.

### DIFF
--- a/docs/sphinx/configuration.rst
+++ b/docs/sphinx/configuration.rst
@@ -115,6 +115,11 @@ Defines basic plugin properties.
 
 File extensions just be (.conf|.json).
 
+[pending]
+
+- **depth** - The pending queue depth.  Default: 100K
+
+
 [model]
 -------
 

--- a/src/gofer/agent/config.py
+++ b/src/gofer/agent/config.py
@@ -107,6 +107,11 @@ PLUGIN_SCHEMA = (
             ('authenticator', OPTIONAL, ANY),
         )
     ),
+    ('pending', OPTIONAL,
+        (
+            ('depth', REQUIRED, NUMBER),
+        )
+    ),
     ('model', OPTIONAL,
         (
             ('managed', OPTIONAL, '(0|1|2)'),
@@ -133,6 +138,9 @@ PLUGIN_DEFAULTS = {
         'threads': '1',
         'accept': ',',
         'forward': ','
+    },
+    'pending': {
+        'depth': '100000'
     },
     'model': {
         'managed': '2'

--- a/src/gofer/agent/config.py
+++ b/src/gofer/agent/config.py
@@ -69,6 +69,11 @@ AGENT_SCHEMA = (
 #   authenticator
 #      The (optional) fully qualified Authenticator to be loaded from the PYTHON path.
 #
+# [pending]
+#
+#   depth
+#      The depth of the pending request queue.  Default: 10K.
+#
 # [model]
 #
 #   managed
@@ -140,7 +145,7 @@ PLUGIN_DEFAULTS = {
         'forward': ','
     },
     'pending': {
-        'depth': '100000'
+        'depth': '10000'
     },
     'model': {
         'managed': '2'

--- a/src/gofer/agent/plugin.py
+++ b/src/gofer/agent/plugin.py
@@ -203,7 +203,7 @@ class Plugin(object):
         self.actions = []
         self.dispatcher = Dispatcher()
         self.whiteboard = Whiteboard()
-        self.scheduler = Scheduler(self)
+        self.scheduler = Scheduler(self, int(descriptor.pending.depth))
         self.delegate = Delegate()
         self.authenticator = None
         self.consumer = None

--- a/src/gofer/agent/rmi.py
+++ b/src/gofer/agent/rmi.py
@@ -146,14 +146,16 @@ class Scheduler(Thread):
     Processes the *pending* queue.
     """
     
-    def __init__(self, plugin):
+    def __init__(self, plugin, depth):
         """
         :param plugin: A plugin.
         :type plugin: gofer.agent.plugin.Plugin
+        :param depth: The max queue depth.
+        :type depth: int
         """
         Thread.__init__(self, name='scheduler:%s' % plugin.stream)
         self.plugin = plugin
-        self.pending = Pending(plugin.stream)
+        self.pending = Pending(plugin.stream, depth)
         self.builtin = Builtin(plugin)
         self.setDaemon(True)
 

--- a/src/gofer/rmi/store.py
+++ b/src/gofer/rmi/store.py
@@ -24,12 +24,29 @@ from logging import getLogger
 from Queue import Queue, Empty
 
 from gofer import NAME, Thread, Singleton
+from gofer.common import utf8
 from gofer.common import mkdir, rmdir, unlink
 from gofer.messaging import Document
 from gofer.rmi.tracker import Tracker
 
 
 log = getLogger(__name__)
+
+
+class FileCorrupted(Exception):
+    """
+    File corrupted and likely discarded.
+    """
+
+    def __init__(self, path):
+        super(FileCorrupted, self).__init__(path)
+
+    @property
+    def path(self):
+        return self.args[0]
+
+    def __str__(self):
+        return "File %s corrupted.  Discarded" % self.path
 
 
 class Pending(object):
@@ -40,6 +57,13 @@ class Pending(object):
     __metaclass__ = Singleton
 
     PENDING = '/var/lib/%s/messaging/pending' % NAME
+
+    # The queue depth
+    MAX_DEPTH = 100000
+
+    # The soft threshold determines when the journal
+    # file path is queued instead of the actual request
+    SOFT_THRESHOLD = 50
 
     @staticmethod
     def _write(request, path):
@@ -54,7 +78,7 @@ class Pending(object):
         try:
             body = request.dump()
             fp.write(body)
-            log.debug('wrote [%s]: %s', path, body)
+            log.debug('Writing [%s]: %s', path, body)
         finally:
             fp.close()
 
@@ -66,6 +90,7 @@ class Pending(object):
         :type path: str
         :return: The read request.
         :rtype: Document
+        :raise FileCorrupted:
         """
         fp = open(path)
         try:
@@ -73,11 +98,11 @@ class Pending(object):
                 request = Document()
                 body = fp.read()
                 request.load(body)
-                log.debug('read [%s]: %s', path, body)
+                log.debug('Read [%s]: %s', path, body)
                 return request
             except ValueError:
-                log.error('%s corrupt (discarded)', path)
                 os.unlink(path)
+                raise FileCorrupted(path)
         finally:
             fp.close()
 
@@ -91,13 +116,15 @@ class Pending(object):
         paths = [os.path.join(path, name) for name in os.listdir(path)]
         return sorted(paths)
 
-    def __init__(self, stream):
+    def __init__(self, stream, depth=MAX_DEPTH):
         """
         :param stream: The stream name.
         :type stream: str
+        :param depth: The queue depth.
+        :type depth: int
         """
         self.stream = stream
-        self.queue = Queue(maxsize=100)
+        self.queue = Queue(maxsize=depth)
         self.is_open = False
         self.sequential = Sequential()
         self.journal = {}
@@ -116,11 +143,11 @@ class Pending(object):
         log.info('Using: %s', path)
         for path in self._list():
             log.info('Restoring: %s', path)
-            request = Pending._read(path)
-            if not request:
-                # read failed
-                continue
-            self._put(request, path)
+            try:
+                request = Pending._read(path)
+                self._put(request, path)
+            except FileCorrupted, fe:
+                log.debug(utf8(fe))
         self.is_open = True
 
     def put(self, request):
@@ -147,7 +174,7 @@ class Pending(object):
         """
         while not Thread.aborted():
             try:
-                return self.queue.get(timeout=10)
+                return self._get(timeout=10)
             except Empty:
                 pass
 
@@ -161,9 +188,9 @@ class Pending(object):
         try:
             path = self.journal[sn]
             unlink(path)
-            log.debug('%s committed', sn)
+            log.debug('Request %s committed', sn)
         except KeyError:
-            log.warn('%s not found for commit', sn)
+            log.warn('Request %s not found for commit', sn)
 
     def delete(self):
         """
@@ -175,7 +202,7 @@ class Pending(object):
         self._drain()
         path = os.path.join(Pending.PENDING, self.stream)
         rmdir(path)
-        log.info('%s, deleted', path)
+        log.info('File %s deleted', path)
 
     def _drain(self):
         """
@@ -184,24 +211,55 @@ class Pending(object):
         self.is_open = False
         while not Thread.aborted():
             try:
-                request = self.queue.get(timeout=1)
+                request = self._get(timeout=1)
                 self.commit(request.sn)
             except Empty:
                 break
 
+    def _get(self, timeout=10):
+        """
+        Get the next pending request to be dispatched.
+        The queued *thing* can be either a request or the path to
+        a journal file.  When a path is detected, the file is read
+        and the actual request is read.
+        :return: The next pending request.
+        :rtype: Document
+        :raise Empty: when queue empty.
+        """
+        while True:
+            if Thread.aborted():
+                raise Empty()
+            thing = self.queue.get(timeout=timeout)
+            if isinstance(thing, str):
+                try:
+                    request = Pending._read(thing)
+                except (IOError, OSError, FileCorrupted), fe:
+                    log.warn(utf8(fe))
+                    continue
+            else:
+                request = thing
+            request.ts = time()
+            return request
+
     def _put(self, request, jnl_path):
         """
         Enqueue the request.
+        When the queue depth threshold is exceeded, the path to the
+        journal file is queued instead of the actual request. This
+        is done to reduce memory footprint for long backlogs.
         :param request: An AMQP request.
         :type request: Document
         :param jnl_path: Path to the associated journal file.
         :type jnl_path: str
         """
-        request.ts = time()
         tracker = Tracker()
         tracker.add(request.sn, request.data)
         self.journal[request.sn] = jnl_path
-        self.queue.put(request)
+        if self.queue.qsize() > Pending.SOFT_THRESHOLD:
+            thing = jnl_path
+        else:
+            thing = request
+        self.queue.put(thing)
 
 
 class Sequential(object):

--- a/src/gofer/rmi/store.py
+++ b/src/gofer/rmi/store.py
@@ -59,7 +59,7 @@ class Pending(object):
     PENDING = '/var/lib/%s/messaging/pending' % NAME
 
     # The queue depth
-    MAX_DEPTH = 100000
+    MAX_DEPTH = 10000
 
     # The soft threshold determines when the journal
     # file path is queued instead of the actual request

--- a/test/functional/plugins/testplugin.conf
+++ b/test/functional/plugins/testplugin.conf
@@ -27,6 +27,11 @@
 #   host_validation
 #      The (optional) flag indicates SSL host validation should be performed.
 #
+# [pending]
+#
+#   depth
+#      The pending queue depth.  Default: 100K
+#
 # [model]
 #
 #   managed
@@ -46,6 +51,9 @@
 [main]
 enabled=1
 forward=*
+
+[pending]
+depth=500
 
 [messaging]
 uuid=TEST


### PR DESCRIPTION
Larger pending queue depth that is also configurable for each plugin. The default is: 10k. The pending queue continues to queue the actual request unless the queue depth exceeds a threshold. When the threshold is reached, the journal file path is stored instead to minimize the memory footprint. With a smaller (deterministic) memory footprint for each queued request (path), the depth can be safely be very large. The default is 100K.

A mirror PR (with merge conflicts resolved) has been submitted against master.  If 2.6 is merged forward to master, the _-s ours_ flag should be used.
