### PR TITLE
2.4 compat - Exception not a new-style class until 2.5.

### DIFF
--- a/src/gofer/messaging/adapter/proton/model.py
+++ b/src/gofer/messaging/adapter/proton/model.py
@@ -49,7 +49,7 @@ class Error(Exception):
         :param code: The qpid error code.
         :type code: int
         """
-        super(Error, self).__init__(description)
+        Exception.__init__(self, description)
         self.code = code
 
 

--- a/src/gofer/messaging/adapter/qpid/model.py
+++ b/src/gofer/messaging/adapter/qpid/model.py
@@ -50,7 +50,7 @@ class Error(Exception):
         :param code: The qpid error code.
         :type code: int
         """
-        super(Error, self).__init__(description)
+        Exception.__init__(self, description)
         self.code = code
 
 

--- a/src/gofer/messaging/auth.py
+++ b/src/gofer/messaging/auth.py
@@ -42,7 +42,8 @@ class ValidationFailed(DocumentError):
         :param document: The (optional) invalid document.
         :type document: Document
         """
-        super(ValidationFailed, self).__init__(
+        DocumentError.__init__(
+            self,
             self.CODE,
             self.DESCRIPTION,
             document or Document(),

--- a/src/gofer/messaging/model.py
+++ b/src/gofer/messaging/model.py
@@ -46,7 +46,7 @@ class DocumentError(ModelError):
         :param details: A detailed description of what failed.
         :type details: str
         """
-        Exception.__init__(self, ' : '.join((description or code, details or '')))
+        ModelError.__init__(self, ' : '.join((description or code, details or '')))
         self.code = code
         self.description = description
         self.document = document
@@ -68,7 +68,8 @@ class VersionError(DocumentError):
         :param found: The version found in the document.
         :type found: str
         """
-        super(VersionError, self).__init__(
+        DocumentError.__init__(
+            self,
             self.CODE,
             self.DESCRIPTION,
             document,


### PR DESCRIPTION
Can't use `super()` with Exceptions.