### PR TITLE
export PYTHONOPTIMIZE in the init script

### DIFF
--- a/etc/init.d/goferd
+++ b/etc/init.d/goferd
@@ -16,7 +16,10 @@ PROG=goferd
 LOCK=/var/lock/subsys/$PROG
 PID=/var/run/$PROG.pid
 
-. /etc/sysconfig/$PROG
+[ -f /etc/sysconfig/$PROG ] && . /etc/sysconfig/$PROG
+
+# this is a no-op if the env var isn't set
+export PYTHONOPTIMIZE
 
 start() {
   if [ -e $PID ]; then


### PR DESCRIPTION
*sigh*

This is why we use systemd now.

I also added a check to make sure /etc/sysconfig/goferd exists before
sourcing it, because it's The Right Thing To Do™