### PR TITLE
Resend logic removed from proton reliability.

### DIFF
--- a/src/gofer/messaging/adapter/proton/model.py
+++ b/src/gofer/messaging/adapter/proton/model.py
@@ -17,7 +17,7 @@ from proton import Message
 from gofer.common import utf8
 from gofer.messaging.adapter.model import Messenger, BaseExchange, BaseQueue
 from gofer.messaging.adapter.proton.connection import Connection
-from gofer.messaging.adapter.proton.reliability import reliable, resend
+from gofer.messaging.adapter.proton.reliability import reliable
 
 
 log = getLogger(__name__)
@@ -103,7 +103,6 @@ class Method(Messenger):
             'method': 'request'
         }
 
-    @resend
     def send(self, request):
         """
         Send the request.

--- a/src/gofer/messaging/adapter/proton/producer.py
+++ b/src/gofer/messaging/adapter/proton/producer.py
@@ -15,7 +15,7 @@ from proton import Message
 
 from gofer.messaging.adapter.model import BaseSender
 from gofer.messaging.adapter.proton.connection import Connection
-from gofer.messaging.adapter.proton.reliability import reliable, resend
+from gofer.messaging.adapter.proton.reliability import reliable
 
 
 log = getLogger(__name__)
@@ -85,7 +85,6 @@ class Sender(BaseSender):
         """
         pass
 
-    @resend
     def send(self, address, content, ttl=None):
         """
         Send a message.

--- a/src/gofer/messaging/adapter/proton/reliability.py
+++ b/src/gofer/messaging/adapter/proton/reliability.py
@@ -13,8 +13,8 @@
 from time import sleep
 from logging import getLogger
 
-from proton import ConnectionException, Delivery
-from proton.utils import SendException, LinkDetached
+from proton import ConnectionException
+from proton.utils import LinkDetached
 
 from gofer.common import Thread, utf8
 from gofer.messaging.adapter.model import NotFound
@@ -53,22 +53,4 @@ def reliable(fn):
                 log.error(utf8(pe))
                 repair = messenger.repair
                 sleep(DELAY)
-    return _fn
-
-
-def resend(fn):
-    @reliable
-    def _fn(sender, *args, **kwargs):
-        retry = MAX_RESEND
-        delay = RESEND_DELAY
-        while not Thread.aborted() and retry > 0:
-            try:
-                return fn(sender, *args, **kwargs)
-            except SendException, le:
-                log.error(utf8(le.state))
-                if le.state == Delivery.RELEASED:
-                    sleep(delay)
-                    retry -= 1
-                else:
-                    raise
     return _fn


### PR DESCRIPTION
The resend logic existed to support issues found during testing with Qpid Dispatch Router.  Sending Messages to a queue that does not exist resulted in `SendError` being raised.  After further testing, this behavior was correct when the qdrouterd was not configured properly.  If the destination (queue) matches a link route prefix, the link attach will fail (`LinkDetached` is raised) when the queue does not exist.  Also, if the connection to the broker is down - a `LinkDetached` is raised.