### PR TITLE
Connections closed after each request.

### DIFF
--- a/gofer.spec
+++ b/gofer.spec
@@ -202,7 +202,7 @@ Summary: Gofer Qpid proton messaging adapter python package
 Group: Development/Languages
 BuildRequires: python
 Requires: python-%{name} = %{version}
-Requires: python-qpid-proton >= 0.9-5
+Requires: python-qpid-proton >= 0.9-13
 
 %description -n python-%{name}-proton
 Provides the gofer qpid proton messaging adapter package.

--- a/src/gofer/agent/rmi.py
+++ b/src/gofer/agent/rmi.py
@@ -16,7 +16,7 @@
 from time import time
 from logging import getLogger
 
-from gofer.common import Thread, Local
+from gofer.common import Thread, Local, released
 from gofer.rmi.tracker import Tracker
 from gofer.rmi.store import Pending, Empty
 from gofer.messaging import Document, Producer
@@ -68,6 +68,7 @@ class Task:
     def request(self):
         return self.transaction.request
 
+    @released
     def __call__(self):
         """
         Dispatch received request.

--- a/src/gofer/rmi/policy.py
+++ b/src/gofer/rmi/policy.py
@@ -20,7 +20,7 @@ Contains request delivery policies.
 from logging import getLogger
 from uuid import uuid4
 
-from gofer.common import Thread, Options, nvl, utf8
+from gofer.common import Thread, Options, nvl, utf8, released
 from gofer.messaging import Document, DocumentError
 from gofer.messaging import Producer, Reader, Queue, Exchange
 from gofer.rmi.dispatcher import Return, RemoteException
@@ -263,6 +263,7 @@ class Policy(object):
         except Exception:
             log.error('progress callback failed', exc_info=1)
 
+    @released
     def __call__(self, request):
         """
         Send the request then read the reply.

--- a/test/functional/plugins/testplugin.py
+++ b/test/functional/plugins/testplugin.py
@@ -276,7 +276,7 @@ class Heartbeat:
     Provide agent heartbeat.
     """
 
-    # @action(seconds=HEARTBEAT)
+    @action(seconds=HEARTBEAT)
     def heartbeat(self):
         return self.send()
 


### PR DESCRIPTION
The connection is closed on completion of each request.  The goal is to minimize the number of open (unused) connections.  This also reduces the noise in the log when these connections timeout due to overdue heartbeat.

This must not be merged until:

- https://issues.apache.org/jira/browse/PROTON-1010
- https://issues.apache.org/jira/browse/PROTON-1044

are fixed and released.