### PR TITLE
Use LSB common pidfile kill functions to stop

### DIFF
--- a/etc/init.d/goferd
+++ b/etc/init.d/goferd
@@ -46,18 +46,12 @@ start() {
 
 stop() {
   echo -n "Stopping $PROG"
-  if [ -e $PID ]; then
-    pid=$(cat $PID)
-  fi
-  kill -9 $pid >/dev/null 2>&1
+
+  killproc -p $PID $PROG
   RETVAL=$?
-  if [ $RETVAL -eq "0" ]; then
-    rm -f $LOCK
-    success
-  else
-    failure
-  fi
   echo
+
+  rm -f $LOCK
   return $RETVAL
 }
 


### PR DESCRIPTION
This fixes an issue where repeatedly running stop could kill a random process that just coincidentally acquires the same PID after `goferd` is stopped.