### PR TITLE
Fix proton reliable send.

### DIFF
--- a/src/gofer/messaging/adapter/proton/producer.py
+++ b/src/gofer/messaging/adapter/proton/producer.py
@@ -85,6 +85,7 @@ class Sender(BaseSender):
         """
         pass
 
+    @reliable
     def send(self, address, content, ttl=None):
         """
         Send a message.


### PR DESCRIPTION
Add missing `@reliable` decorator on Producer.send().