### PR TITLE
Support RMI invocation models

### DIFF
--- a/docs/sphinx/decorators.rst
+++ b/docs/sphinx/decorators.rst
@@ -35,6 +35,13 @@ Options:
     - default: None
     - note: **DEPRECATED** in 2.7
 
+- **model** - the RMI execution model (direct|fork).
+  The *fork* model spawns a child process for each method invocation.
+    - required: No
+    - type: str
+    - default: direct
+    - note: Added in 2.8
+
 @pam
 ----
 

--- a/docs/sphinx/examples/python.rst
+++ b/docs/sphinx/examples/python.rst
@@ -38,6 +38,7 @@ Code:   ``/user/share/gofer/plugins/plugin.py``
 ::
 
  from gofer.decorators import remote
+ from gofer.rmi.model.FORK
  from gofer.agent.plugin import Plugin
 
  # (optional) access to the plugin descriptor
@@ -53,7 +54,7 @@ Code:   ``/user/share/gofer/plugins/plugin.py``
         print '%s %s' % (woof, words)
         return 'Yes master.  I will bark because that is what dogs do.'
 
-    @remote
+    @remote(model=FORK)
     def wag(self, n):
         for i in range(0, n):
             print 'wag'

--- a/docs/sphinx/notes.rst
+++ b/docs/sphinx/notes.rst
@@ -261,3 +261,26 @@ Deprecated:
     - The @pam decorator.
     - The @user decorator.
     - The *pam* property in the message.
+
+
+gofer 2.8
+^^^^^^^^^
+
+Notes:
+
+- Added support for RMI invocation models.  The ``direct`` model is the default and
+  invokes the remote method within the ``goferd`` process.  This is the model used by
+  <= 2.7.  The new ``fork`` model spawns a child process for each method invocation.
+  Invoking the method in a separate process provides isolation and better cancellation
+  behavior.  The isolation protects ``goferd`` against memory leaks and corruption
+  potentially introduced by plugins (or code used by plugins). When using the ``fork``
+  model, RMI cancellation is implemented by killing the child process.  As a result
+  cancellation is certain and immediate regardless of whether cancellation is implemented
+  by the method.
+
+Fixes:
+
+- Proton message sending reliability regression introduced in 2.7.
+
+
+Deprecated:

--- a/etc/init.d/goferd
+++ b/etc/init.d/goferd
@@ -46,11 +46,9 @@ start() {
 
 stop() {
   echo -n "Stopping $PROG"
-
   killproc -p $PID $PROG
   RETVAL=$?
   echo
-
   rm -f $LOCK
   return $RETVAL
 }

--- a/gofer.spec
+++ b/gofer.spec
@@ -139,6 +139,7 @@ Requires: python-ctypes
 Requires: python-simplejson
 Requires: python-hashlib
 Requires: python-uuid
+Requires: python-multiprocessing
 %endif
 
 %description -n python-%{name}

--- a/src/gofer/common.py
+++ b/src/gofer/common.py
@@ -16,6 +16,7 @@
 import os
 import inspect
 import errno
+import new as _new
 
 from threading import local as Local
 from threading import Thread as _Thread
@@ -110,6 +111,23 @@ def valid_path(path, mode=os.R_OK):
         raise ValueError('"%s" not found' % path)
     if not os.access(path, mode):
         raise ValueError('"%s" insufficient permissions' % path)
+
+
+def new(T, state=None):
+    """
+    Build objects.
+    :param T: The type of object to build.
+    :type T: type|class
+    :param state: Optional object state.
+    :type state: dict
+    :return: The new object.
+    """
+    if issubclass(T, object):
+        inst = T.__new__(T)
+        inst.__dict__.update(state or {})
+    else:
+        inst = _new.instance(T, state)
+    return inst
 
 
 class Thread(_Thread):

--- a/src/gofer/decorators.py
+++ b/src/gofer/decorators.py
@@ -17,6 +17,7 @@ import inspect
 
 from gofer import NAME, Options
 from gofer.rmi.decorator import Remote
+from gofer.rmi.model import DIRECT, valid_model
 from gofer.agent.decorator import Actions
 from gofer.agent.decorator import Delegate
 
@@ -32,22 +33,28 @@ def options(fn):
     if not hasattr(fn, NAME):
         opt = Options()
         opt.security = []
+        opt.call = Options(model=DIRECT)
         setattr(fn, NAME, opt)
     else:
         opt = getattr(fn, NAME)
     return opt
 
 
-def remote(fx=None, secret=None):
+def remote(fx=None, model=DIRECT, secret=None):
     """
     The *remote* decorator.
     Used to expose function/methods as RMI targets.
-    :param secret: An optional shared secret.
+    :param fx: The function being decorated when called without params.
+    :type fx: function
+    :param model: The RMI call model (direct|forked)
+    :type model: str
+    :param secret: An optional shared secret. *DEPRECATED*
     :type secret: str
     :return: The decorated function.
     """
     def inner(fn):
         opt = options(fn)
+        opt.call.model = valid_model(model)
         if secret:
             required = Options()
             required.secret = secret

--- a/src/gofer/devel/test.py
+++ b/src/gofer/devel/test.py
@@ -13,7 +13,7 @@
 #
 
 
-from mock import patch
+from mock import patch, Mock
 
 
 class Module(object):
@@ -27,6 +27,22 @@ class Fake(object):
     def __init__(self, *args, **keywords):
         self.args = args
         self.keywords = keywords
+
+
+class SideEffect(object):
+
+    def __init__(self, *values):
+        self.values = iter(values)
+
+    def __call__(self, *args, **kwargs):
+        value = self.values.next()
+        if isinstance(value, Mock):
+            return value
+        if callable(value):
+            value = value(*args, **kwargs)
+        if isinstance(value, Exception):
+            raise value
+        return value
 
 
 class Import(object):

--- a/src/gofer/rmi/model/__init__.py
+++ b/src/gofer/rmi/model/__init__.py
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
+"""
+RMI call models.
+"""
+
+from gofer.rmi.model import direct, fork
+
+# call models
+DIRECT = 'direct'
+FORK = 'fork'
+
+ALL = {
+    DIRECT: direct.Call,
+    FORK: fork.Call,
+}
+
+
+def valid_model(model):
+    if model in ALL:
+        return model
+    else:
+        raise ValueError('model must be: %s' % '|'.join(ALL))

--- a/src/gofer/rmi/model/child.py
+++ b/src/gofer/rmi/model/child.py
@@ -1,0 +1,87 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
+from logging import getLogger
+
+from gofer import utf8
+from gofer.agent.rmi import Context
+from gofer.rmi.model import protocol
+
+
+log = getLogger(__name__)
+
+
+class Call(protocol.Call):
+    """
+    The child-side of the forked call.
+    """
+
+    def __call__(self, pipe):
+        """
+        Perform RMI on the child-side of the forked call
+        as follows:
+          - Reset the RMI context.
+          - Invoke the method
+          - Send result: retval, progress, raised exception.
+        All output is sent to the parent using the inter-process pipe.
+        :param pipe: A message pipe.
+        :type  pipe: multiprocessing.Connection
+        """
+        try:
+            context = Context.current()
+            context.cancelled = lambda: False
+            context.progress = Progress(pipe)
+            result = self.method(*self.args, **self.kwargs)
+            reply = protocol.Result(result)
+            reply.send(pipe)
+        except Exception, e:
+            log.exception(utf8(e))
+            reply = protocol.Raised(e)
+            reply.send(pipe)
+
+
+class Progress(object):
+    """
+    Provides progress reporting to the parent through the pipe.
+    :ivar pipe: A message pipe.
+    :type pipe: multiprocessing.Connection
+    :ivar total: The total work units.
+    :type total: int
+    :ivar completed: The completed work units.
+    :type completed: int
+    :ivar details: The reported details.
+    :type details: object
+    """
+
+    def __init__(self, pipe):
+        """
+        :param pipe: A message pipe.
+        :type  pipe: multiprocessing.Connection
+        """
+        self.pipe = pipe
+        self.total = 0
+        self.completed = 0
+        self.details = {}
+
+    def report(self):
+        """
+        Report progress.
+        """
+        payload = protocol.ProgressPayload(
+            total=self.total,
+            completed=self.completed,
+            details=self.details)
+        reply = protocol.Progress(payload)
+        reply.send(self.pipe)

--- a/src/gofer/rmi/model/direct.py
+++ b/src/gofer/rmi/model/direct.py
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
+from gofer.rmi.model import protocol
+
+
+class Call(protocol.Call):
+    """
+    Direct call model.
+    """
+
+    def __call__(self):
+        """
+        Invoke the method.
+        :return: Whatever method returned.
+        """
+        return self.method(*self.args, **self.kwargs)

--- a/src/gofer/rmi/model/fork.py
+++ b/src/gofer/rmi/model/fork.py
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
+from gofer.rmi.model import parent
+
+
+class Call(parent.Call):
+    """
+    Fork call model.
+    """
+    pass

--- a/src/gofer/rmi/model/parent.py
+++ b/src/gofer/rmi/model/parent.py
@@ -1,0 +1,186 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
+from logging import getLogger
+from multiprocessing import Process, Pipe
+from threading import Thread
+from time import sleep
+
+from gofer.agent.rmi import Context
+from gofer.rmi.model import protocol
+from gofer.rmi.model.child import Call as Target
+
+
+log = getLogger(__file__)
+
+
+POLL = 0.10
+
+
+class Call(protocol.Call):
+    """
+    The parent-side of the RMI call invoked in a child process.
+    After the fork, the child invokes the method and relays events
+    back using the inter-process queue.
+    """
+
+    def __call__(self):
+        """
+        Invoke the RMI as follows:
+          - Fork
+          - Start the monitor.
+          - Read and dispatch reply messages.
+        :return: Whatever method returned.
+        """
+        inbound, outbound = Pipe()
+        target = Target(self.method, *self.args, **self.kwargs)
+        child = Process(target=target, args=(outbound,))
+        monitor = Monitor(Context.current(), child, outbound)
+        try:
+            child.start()
+            monitor.start()
+            retval = self.read(inbound)
+            return retval
+        finally:
+            inbound.close()
+            outbound.close()
+            monitor.stop()
+            child.join()
+
+    def read(self, pipe):
+        """
+        Read the reply queue and dispatch messages until *End* is raised..
+        :param pipe: A message queue.
+        :type  pipe: multiprocessing.Connection
+        """
+        while True:
+            try:
+                reply = protocol.Reply.read(pipe)
+                reply()
+            except protocol.End, end:
+                return end.result
+
+
+class Monitor(Thread):
+    """
+    Provides monitoring of cancellation.
+    When cancel is detected, the child process is terminated.
+    :ivar context: The RMI context.
+    :type context: Context
+    :ivar child: The child process.
+    :type child: Process
+    :ivar pipe: A message pipe.
+    :type pipe: multiprocessing.Connection
+    :ivar poll: Main polling loop boolean.
+    :type poll: bool
+    """
+
+    NAME = 'monitor'
+    POLL = 0.10
+
+    def __init__(self, context, child, pipe):
+        """
+        :param context: The RMI context.
+        :type  context: Context
+        :param child: The child process.
+        :type  child: Process
+        :param pipe: A message pipe.
+        :type  pipe: multiprocessing.Connection
+        """
+        super(Monitor, self).__init__(name=Monitor.NAME)
+        self.context = context
+        self.child = child
+        self.pipe = pipe
+        self.poll = True
+        self.setDaemon(True)
+
+    def stop(self):
+        """
+        Stop the thread.
+        """
+        self.poll = False
+        self.join()
+
+    def run(self):
+        """
+        Test for cancellation.
+        When cancel is detected, the child process is terminated.
+        """
+        while self.poll:
+            if self.context.cancelled():
+                self.pipe.send(0)
+                self.child.terminate()
+                break
+            else:
+                sleep(Monitor.POLL)
+
+
+class Result(protocol.Result):
+    """
+    Called when a RESULT message is received.
+    """
+
+    def __call__(self):
+        """
+        :raise End: always.
+        """
+        raise protocol.End(self.payload)
+
+
+class Progress(protocol.Progress):
+    """
+    Called when a PROGRESS message is received.
+    """
+
+    def __call__(self):
+        """
+        Relay to RMI context progress reporter.
+        """
+        context = Context.current()
+        context.progress.__dict__.update(self.payload.__dict__)
+        context.progress.report()
+
+
+class Error(protocol.Error):
+    """
+    Called when a ERROR message is received.
+    """
+
+    def __call__(self):
+        """
+        An exception is raised to report the error.
+        :raise Exception: always.
+        """
+        raise Exception(self.payload)
+
+
+class Raised(protocol.Raised):
+    """
+    Called when a RAISED (exception) message is received.
+    """
+
+    def __call__(self):
+        """
+        The reported exception is instantiated and raised.
+        :raise Exception: always.
+        """
+        raise self.payload
+
+
+# register reply message handling.
+protocol.Reply.register(Result.CODE, Result)
+protocol.Reply.register(Progress.CODE, Progress)
+protocol.Reply.register(Error.CODE, Error)
+protocol.Reply.register(Raised.CODE, Raised)

--- a/src/gofer/rmi/model/protocol.py
+++ b/src/gofer/rmi/model/protocol.py
@@ -1,0 +1,223 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
+from logging import getLogger
+
+
+log = getLogger(__file__)
+
+
+class End(Exception):
+    """
+    End of child reply processing.
+    """
+
+    def __init__(self, result=None):
+        """
+        :param result: The RMI retval.
+        """
+        Exception.__init__(self)
+        self.result = result
+
+
+class Call(object):
+    """
+    An RMI call.
+    """
+
+    def __init__(self, method, *args, **kwargs):
+        """
+        :param method: The method to be invoked.
+        :type method: (method, function)
+        :param args: Passed arguments.
+        :type args: tuple
+        :param kwargs: Passed keyword arguments.
+        :type kwargs: dict
+        """
+        self.method = method
+        self.args = args
+        self.kwargs = kwargs
+
+
+class Message(object):
+    """
+    A json encoded message.
+    """
+
+    @classmethod
+    def read(cls, pipe):
+        """
+        Read the next message from the pipe.
+        :param pipe: A message pipe.
+        :type  pipe: multiprocessing.Connection
+        :return: The hydrated message.
+        :rtype: Message
+        """
+        try:
+            message = pipe.recv()
+            if not message:
+                raise EOFError()
+            log.debug('Received: %s', message)
+            return message
+        except EOFError:
+            raise End()
+
+    def send(self, pipe):
+        """
+        Put json encoded (self) into the pipe.
+        :param pipe: A message pipe.
+        :type  pipe: multiprocessing.Connection
+        """
+        pipe.send(self)
+        log.debug('Sent: %s', self)
+
+    def __str__(self):
+        return ':'.join((self.__class__.__name__, str(self.__dict__)))
+
+
+class Reply(Message):
+    """
+    A child reply message.
+    This is an event relayed by the child process that needs
+    to be propagated to the parent.
+    :cvar registry: Message objects mapped to codes.
+    :type registry: dict
+    :ivar code: Message code.
+    :type code: str
+    :ivar payload: Message payload.
+    :type payload: object
+    """
+
+    registry = {}
+
+    def __init__(self, code, payload):
+        """
+        :param code: Message code.
+        :type code: str
+        :param payload: Message payload.
+        :type payload: object
+        """
+        self.code = code
+        self.payload = payload
+
+    @staticmethod
+    def register(code, target):
+        """
+        Register a reply class to its code.
+        When a message with the *code* is received, the object is
+        hydrated and called.
+        :param code: A reply code.
+        :type code: str
+        :param target: A reply class.
+        :type target: Reply
+        """
+        Reply.registry[code] = target
+
+    def __call__(self):
+        """
+        Find the registered message class by code and create
+        an instance it with the payload.  Then, the message is
+        invoked to propagate event on the parent.
+        """
+        try:
+            T = Reply.registry[self.code]
+            target = T(self.payload)
+            target()
+        except KeyError:
+            log.debug('Reply: [%s] discarded', self.code)
+
+
+class ProgressPayload(object):
+    """
+    The message payload.
+    :ivar total: The total work units.
+    :type total: int
+    :ivar completed: The completed work units.
+    :type completed: int
+    :ivar details: The reported details.
+    :type details: object
+    """
+    def __init__(self, total, completed, details):
+        """
+        :ivar total: The total work units.
+        :type total: int
+        :ivar completed: The completed work units.
+        :type completed: int
+        :ivar details: The reported details.
+        :type details: object
+        """
+        self.total = total
+        self.completed = completed
+        self.details = details
+
+
+class Progress(Reply):
+    """
+    A PROGRESS reporting event.
+    """
+
+    CODE = 'PROGRESS'
+
+    def __init__(self, payload):
+        """
+        :param payload: The reported progress.
+        :type payload: ProgressPayload
+        """
+        super(Progress, self).__init__(self.CODE, payload)
+
+
+class Result(Reply):
+    """
+    A RESULT reporting event.
+    """
+
+    CODE = 'RESULT'
+
+    def __init__(self, payload):
+        """
+        :param payload: The reported result.
+        :type payload: object
+        """
+        super(Result, self).__init__(self.CODE, payload)
+
+
+class Error(Reply):
+    """
+    An ERROR reporting event.
+    """
+
+    CODE = 'ERROR'
+
+    def __init__(self, payload):
+        """
+        :param payload: The reported result.
+        :type payload: object:
+        """
+        super(Error, self).__init__(self.CODE, payload)
+
+
+class Raised(Reply):
+    """
+    A RAISED (exception) reporting event.
+    """
+
+    CODE = 'RAISED'
+
+    def __init__(self, payload):
+        """
+        :param payload: The reported result.
+        :type payload: object
+        """
+        super(Raised, self).__init__(self.CODE, payload)

--- a/test/functional/agent.py
+++ b/test/functional/agent.py
@@ -146,5 +146,5 @@ if __name__ == '__main__':
     threads = int(options.threads)
     auth = options.auth
     exchange = options.exchange
-    print 'starting agent, threads=%d, url=%s' % (threads, url)
+    print 'starting agent, pid=%d, threads=%d, url=%s' % (os.getpid(), threads, url)
     agent = TestAgent(url, uuid, threads, auth, exchange)

--- a/test/functional/plugins/forked.conf
+++ b/test/functional/plugins/forked.conf
@@ -1,0 +1,54 @@
+#
+# [main]
+#
+#   enabled
+#      Plugin enabled/disabled (0|1)
+#   name
+#      The (optional) plugin name. The basename of the descriptor is used when not specified.
+#   plugin
+#      The (optional) fully qualified module to be loaded from the PYTHON path.
+#   threads
+#      The (optional) number of threads for the RMI dispatcher.
+#   latency
+#      The (optional) latency (seconds) introduced into RMI execution.
+#   accept
+#      Accept forwarding from.  A comma (,) separated list of plugin names (,=none|*=all).
+#   forward
+#      Forward to.  A comma (,) separated list of plugin names (,=none|*=all).
+#
+# [messaging]
+#
+#   uuid
+#      The (optional) agent identity. This value also specifies the queue name.
+#   url
+#      The (optional) broker connection URL.
+#   cacert
+#      The (optional) SSL CA certificate used to validate the server certificate.
+#   clientcert
+#      The (optional) SSL client certificate.  PEM encoded and contains both key and certificate.
+#   host_validation
+#      The (optional) flag indicates SSL host validation should be performed.
+#
+# [model]
+#
+#   managed
+#      The (optional) level of broker model management.  Default: 2.
+#        - 0 = none
+#        - 1 = declare and bind queue.
+#        - 2 = declare and bind queue; drain and delete queue on explicit detach.
+#   queue
+#      The (optional) AMQP queue name.  This has precedent over uuid.
+#      Format: <exchange>/<queue> where *exchange* is optional.
+#   expiration
+#      The (optional) auto-deleted queue expiration (seconds).
+#
+#
+
+[main]
+enabled=1
+forward=*
+accept=*
+
+[messaging]
+uuid=
+url=

--- a/test/functional/plugins/forked.py
+++ b/test/functional/plugins/forked.py
@@ -1,0 +1,41 @@
+from logging import getLogger
+from time import sleep
+
+from gofer.decorators import remote
+from gofer.rmi.model import FORK
+from gofer.agent.plugin import Plugin
+from gofer.agent.rmi import Context
+
+
+plugin = Plugin.find(__name__)
+log = getLogger(__name__)
+
+
+class Panther(object):
+
+    @remote(model=FORK)
+    def test(self):
+        return 'done'
+
+    @remote(model=FORK)
+    def sleep(self, n=90):
+        while n > 0:
+            log.info('sleeping')
+            sleep(1)
+            n -= 1
+        return 'done'
+
+    @remote(model=FORK)
+    def test_progress(self):
+        total = 30
+        context = Context.current()
+        context.progress.total = total
+        context.progress.report()
+        for n in range(total):
+            context.progress.completed = n
+            context.progress.report()
+        return 'done'
+
+    @remote(model=FORK)
+    def test_exceptions(self):
+        raise ValueError('That was bad')

--- a/test/functional/plugins/testplugin.py
+++ b/test/functional/plugins/testplugin.py
@@ -14,16 +14,15 @@
 # Jeff Ortel <jortel@redhat.com>
 #
 import os
-
-from time import sleep
 from hashlib import sha256
 from logging import getLogger
+from time import sleep
 
-from gofer.decorators import *
 from gofer.agent.plugin import Plugin
 from gofer.agent.rmi import Context
-from gofer.messaging.auth import Authenticator, ValidationFailed
+from gofer.decorators import *
 from gofer.messaging import Producer
+from gofer.messaging.auth import Authenticator, ValidationFailed
 from gofer.rmi.shell import Shell
 
 log = getLogger(__name__)

--- a/test/functional/server.py
+++ b/test/functional/server.py
@@ -432,12 +432,14 @@ def smoke_test(exit=0):
         duck = agent.Duck()
         print duck.fly()
         print duck.quack('aflak')
+        panther = agent.Panther()
+        print panther.test_progress()
     print 'DONE'
     if exit:
         sys.exit(0)
 
 
-def test_cancel():
+def test_cancel(exit=0):
     agent = Agent(wait=0)
     cancel = agent.Cancel()
     sn = cancel.test()
@@ -445,7 +447,29 @@ def test_cancel():
     admin = agent.Admin()
     canceled = admin.cancel(sn)
     print canceled
-    sys.exit(0)
+    if exit:
+        sys.exit(0)
+
+
+def test_forked(exit=0, with_cancel=1):
+    agent = Agent()
+    panther = agent.Panther()
+    print 'forked test(): %s' % panther.test()
+    print 'forked test_progress(): %s' % panther.test_progress()
+    try:
+        panther.test_exceptions()
+    except ValueError:
+        pass
+    if with_cancel:
+        agent = Agent(wait=0)
+        panther = agent.Panther()
+        sn = panther.sleep(30)
+        print 'started: %s' % sn
+        sleep(3)
+        admin = agent.Admin()
+        print 'cancelled: {}'.format(admin.cancel(sn))
+    if exit:
+        sys.exit(0)
 
 
 def get_options():
@@ -481,8 +505,8 @@ if __name__ == '__main__':
     Agent.base_options['authenticator'] = authenticator
 
     # test_zombie()
-
     # test_memory()
+    test_forked()
 
     queue = Queue(address.split('/')[-1].upper())
     queue.durable = False
@@ -491,7 +515,6 @@ if __name__ == '__main__':
     reply_consumer.start(on_reply)
 
     # test_cancel()
-
     # demo_progress(1)
     # test_performance()
 

--- a/test/unit/rmi/model/test_child.py
+++ b/test/unit/rmi/model/test_child.py
@@ -1,0 +1,71 @@
+from unittest import TestCase
+
+from mock import patch, Mock
+
+from gofer.rmi.model.child import Progress, Call
+from gofer.rmi.model import protocol
+
+
+MODULE = 'gofer.rmi.model.child'
+
+
+class Pipe(object):
+
+    def __init__(self):
+        self.pipe = []
+
+    def send(self, thing):
+        self.pipe.append(thing)
+
+    def recv(self):
+        return self.pipe.pop()
+
+
+class TestProgress(TestCase):
+
+    def test_report(self):
+        pipe = Pipe()
+        p = Progress(pipe)
+        p.total = 1
+        p.completed = 2
+        p.details = 'hello'
+
+        # test
+        p.report()
+
+        # validation
+        reply = protocol.Reply.read(pipe)
+        self.assertEqual(reply.code, protocol.Progress.CODE)
+        self.assertEqual(reply.payload.total, p.total)
+        self.assertEqual(reply.payload.completed, p.completed)
+        self.assertEqual(reply.payload.details, p.details)
+
+
+class TestCall(TestCase):
+
+    @patch(MODULE + '.Context.current')
+    def test_call(self, context):
+        method = Mock(return_value=18)
+        pipe = Pipe()
+        call = Call(method, 1, 2, a=1, b=2)
+
+        # test
+        call(pipe)
+
+        # validation
+        reply = protocol.Reply.read(pipe)
+        self.assertTrue(isinstance(context.return_value.progress, Progress))
+        self.assertEqual(reply.code, protocol.Result.CODE)
+        self.assertEqual(reply.payload, method.return_value)
+
+    def test_call_exception(self):
+        method = Mock(side_effect=ValueError)
+        pipe = Pipe()
+        call = Call(method, 1, 2, a=1, b=2)
+
+        # test
+        call(pipe)
+        reply = protocol.Reply.read(pipe)
+
+        # validation
+        self.assertEqual(reply.code, protocol.Raised.CODE)

--- a/test/unit/rmi/model/test_direct.py
+++ b/test/unit/rmi/model/test_direct.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+
+from mock import Mock
+
+from gofer.rmi.model.direct import Call
+
+
+class TestCall(TestCase):
+
+    def test_call(self):
+        method = Mock()
+        args = [1, 2]
+        kwargs = {'A': 1}
+
+        # test
+        model = Call(method, *args, **kwargs)
+        retval = model()
+
+        # validation
+        method.assert_called_once_with(*args, **kwargs)
+        self.assertEqual(retval, method.return_value)

--- a/test/unit/rmi/model/test_fork.py
+++ b/test/unit/rmi/model/test_fork.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+
+from mock import Mock
+
+from gofer.rmi.model.fork import Call
+
+
+class TestCall(TestCase):
+
+    def test_call(self):
+        method = Mock()
+        Call(method)

--- a/test/unit/rmi/model/test_model.py
+++ b/test/unit/rmi/model/test_model.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+
+from gofer.rmi.model import ALL, valid_model
+
+
+class TestModel(TestCase):
+
+    def test_valid_model(self):
+        # valid
+        for model in ALL:
+            self.assertTrue(valid_model(model))
+        # invalid
+        self.assertRaises(ValueError, valid_model, 1234)

--- a/test/unit/rmi/model/test_parent.py
+++ b/test/unit/rmi/model/test_parent.py
@@ -1,0 +1,137 @@
+from unittest import TestCase
+
+from mock import call, patch, Mock
+
+from gofer.rmi.model import protocol
+from gofer.rmi.model.parent import Monitor, Call
+from gofer.rmi.model.parent import Result, Progress, Error, Raised
+
+
+MODULE = 'gofer.rmi.model.parent'
+
+
+class TestMonitor(TestCase):
+
+    @patch(MODULE + '.sleep')
+    def test_run(self, sleep):
+        context = Mock()
+        context.cancelled.side_effect = [False, True]
+        child = Mock()
+        pipe = Mock()
+
+        # test
+        m = Monitor(context, child, pipe)
+        m.run()
+
+        # validation
+        pipe.send.assert_called_once_with(0)
+        child.terminate.assert_called_once_with()
+        sleep.assert_called_once_with(0.10)
+
+    @patch(MODULE + '.Monitor.join')
+    def test_stop(self, join):
+        context = Mock()
+        child = Mock()
+        pipe = Mock()
+
+        # test
+        m = Monitor(context, child, pipe)
+        m.stop()
+
+        # validation
+        self.assertEqual(m.poll, False)
+        join.assert_called_once_with()
+
+
+class TestReplies(TestCase):
+
+    def test_result(self):
+        payload = 'done'
+        reply = Result(payload)
+
+        # test
+        try:
+            reply()
+            self.fail(msg='End not raised')
+        except protocol.End, end:
+            self.assertEqual(end.result, payload)
+
+    @patch(MODULE + '.Context.current')
+    def test_progress(self, current):
+        class P(object):
+            report = Mock()
+        context = Mock()
+        context.progress = P()
+        current.return_value = context
+        payload = protocol.ProgressPayload(1, 2, 3)
+        reply = Progress(payload)
+
+        # test
+        reply()
+
+        context.progress.report.assert_called_once_with()
+        self.assertEqual(context.progress.__dict__, payload.__dict__)
+
+    def test_error(self):
+        payload = 18
+        reply = Error(payload)
+        self.assertRaises(Exception, reply)
+
+    def test_raised(self):
+        payload = ValueError()
+
+        # test
+        reply = Raised(payload)
+        try:
+            reply()
+            self.fail(msg='ValueError not raised')
+        except ValueError, e:
+            self.assertEqual(e, payload)
+
+
+class TestCall(TestCase):
+
+    @patch(MODULE + '.Call.read')
+    @patch(MODULE + '.Target')
+    @patch(MODULE + '.Context')
+    @patch(MODULE + '.Process')
+    @patch(MODULE + '.Pipe')
+    @patch(MODULE + '.Monitor')
+    def test_call(self, monitor, pipe, process, context, target, read):
+        inbound = Mock()
+        outbound = Mock()
+        pipe.return_value = inbound, outbound
+
+        # test
+        _call = Call(Mock(), 1, 2, a=1, b=2)
+        _call()
+
+        # validation
+        pipe.assert_called_once_with()
+        target.assert_called_once_with(_call.method, *_call.args, **_call.kwargs)
+        process.assert_called_once_with(target=target.return_value, args=(outbound,))
+        monitor.assert_called_once_with(
+                context.current.return_value, process.return_value, outbound)
+        monitor.return_value.start.assert_called_once_with()
+        read.assert_called_once_with(inbound)
+        monitor.return_value.stop.assert_called_once_with()
+        process.return_value.join.assert_called_once_with()
+
+    @patch(MODULE + '.protocol.Reply')
+    def test_read(self, reply):
+        replies = [Mock(), Mock(side_effect=protocol.End(18))]
+        reply.read.side_effect = replies
+        _call = Call(Mock())
+        pipe = Mock()
+
+        # test
+        retval = _call.read(pipe)
+
+        # validation
+        self.assertEqual(
+            reply.read.call_args_list,
+            [
+                call(pipe),
+                call(pipe)
+            ])
+        self.assertEqual(retval, 18)

--- a/test/unit/rmi/model/test_protocol.py
+++ b/test/unit/rmi/model/test_protocol.py
@@ -1,0 +1,125 @@
+from unittest import TestCase
+
+from mock import Mock
+
+from gofer.rmi.model.protocol import End
+from gofer.rmi.model.protocol import Message, Call, Reply
+from gofer.rmi.model.protocol import Progress, Result, Error, Raised
+
+
+class Pipe(object):
+
+    def __init__(self):
+        self.pipe = []
+
+    def send(self, thing):
+        self.pipe.append(thing)
+
+    def recv(self):
+        return self.pipe.pop()
+
+
+class Person(Message):
+
+    def __init__(self):
+        self.name = None
+        self.age = None
+
+
+class TestEnd(TestCase):
+
+    def test_init(self):
+        end = End(18)
+        self.assertEqual(end.result, 18)
+
+
+class TestMessage(TestCase):
+
+    def test_send_read(self):
+        p_in = Person()
+        p_in.name = 'john'
+        p_in.age = 18
+        pipe = Pipe()
+
+        # test
+        p_in.send(pipe)
+        p = Person.read(pipe)
+
+        # validation
+        self.assertTrue(isinstance(p, Person))
+        self.assertEqual(p.name, p_in.name)
+        self.assertEqual(p.age, p_in.age)
+
+    def test_read_end(self):
+        pipe = Pipe()
+        pipe.send(0)
+        self.assertRaises(End, Person.read, pipe)
+
+
+class TestRequest(TestCase):
+
+    def test_init(self):
+        # test
+        method = Mock()
+        args = (1, 2)
+        kwargs = dict(a=1, b=2)
+        call = Call(method, *args, **kwargs)
+
+        # validation
+        self.assertEqual(call.method, method)
+        self.assertEqual(call.args, args)
+        self.assertEqual(call.kwargs, kwargs)
+
+
+class TestReply(TestCase):
+
+    def test_register(self):
+        code = 18
+        target = Mock()
+        Reply.register(code, target)
+        self.assertEqual(Reply.registry[code], target)
+
+    def test_call(self):
+        code = 18
+        payload = 1234
+        target = Mock()
+        Reply.register(code, target)
+
+        # test
+        reply = Reply(code, payload)
+        reply()
+
+        # validation
+        target.assert_called_once_with(payload)
+        target.return_value.assert_called_once_with()
+
+    def test_call_not_found(self):
+        reply = Reply(44, '')
+        reply()
+
+
+class TestReplies(TestCase):
+
+    def test_progress(self):
+        payload = Mock()
+        reply = Progress(payload)
+        self.assertEqual(reply.code, Progress.CODE)
+        self.assertEqual(reply.payload, payload)
+
+    def test_error(self):
+        payload = Mock()
+        reply = Error(payload)
+        self.assertEqual(reply.code, Error.CODE)
+        self.assertEqual(reply.payload, payload)
+
+    def test_result(self):
+        payload = Mock()
+        reply = Result(payload)
+        self.assertEqual(reply.code, Result.CODE)
+        self.assertEqual(reply.payload, payload)
+
+    def test_raised(self):
+        payload = Mock()
+        reply = Raised(payload)
+        self.assertEqual(reply.code, Raised.CODE)
+        self.assertEqual(reply.payload, payload)

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -23,7 +23,7 @@ from tempfile import mktemp
 from gofer.common import Thread as GThread
 from gofer.common import Singleton, ThreadSingleton, Options
 from gofer.common import synchronized, conditional, released
-from gofer.common import mkdir, rmdir, unlink, nvl, valid_path, utf8
+from gofer.common import mkdir, rmdir, unlink, nvl, valid_path, new, utf8
 from gofer.common import List
 
 
@@ -100,6 +100,14 @@ class Thing4(object):
     @released
     def bar(self):
         pass
+
+
+class Thing5(object):
+    pass
+
+
+class Thing6:
+    pass
 
 
 class TestUtf8(TestCase):
@@ -472,6 +480,21 @@ class TestValidPath(TestCase):
         fp.close()
         os.chmod(self.path, 0x00)
         self.assertRaises(ValueError, valid_path, self.path)
+
+
+class TestNew(TestCase):
+
+    def test_object(self):
+        thing = new(Thing5, dict(a=1, b=2))
+        self.assertTrue(isinstance(thing, Thing5))
+        self.assertEqual(thing.a, 1)
+        self.assertEqual(thing.b, 2)
+
+    def test_type(self):
+        thing = new(Thing6, dict(a=1, b=2))
+        self.assertTrue(isinstance(thing, Thing6))
+        self.assertEqual(thing.a, 1)
+        self.assertEqual(thing.b, 2)
 
 
 class TestList(TestCase):

--- a/test/unit/test_decorators.py
+++ b/test/unit/test_decorators.py
@@ -14,7 +14,9 @@ from unittest import TestCase
 from mock import patch, Mock
 
 from gofer import NAME
-from gofer.decorators import options, remote, pam, user, action, load, unload, initializer
+from gofer.decorators import options, remote, pam, user, action
+from gofer.decorators import load, unload, initializer
+from gofer.decorators import DIRECT
 
 
 class Function(object):
@@ -26,14 +28,24 @@ class TestOptions(TestCase):
     def test_options(self):
         def fn(): pass
         opt = options(fn)
-        self.assertEqual(str(opt), str({'security': []}))
+        self.assertEqual(
+            str(opt),
+            str({
+                'security': [],
+                'call': {'model': DIRECT}
+                }))
         self.assertEqual(getattr(fn, NAME), opt)
 
     def test_options_already(self):
         def fn(): pass
         options(fn)
         opt = options(fn)
-        self.assertEqual(str(opt), str({'security': []}))
+        self.assertEqual(
+            str(opt),
+            str({
+                'security': [],
+                'call': {'model': DIRECT}
+                }))
         self.assertEqual(getattr(fn, NAME), opt)
 
 
@@ -44,7 +56,12 @@ class TestRemote(TestCase):
         def fn(): pass
         remote(fn)
         opt = getattr(fn, NAME)
-        self.assertEqual(str(opt), str({'security': []}))
+        self.assertEqual(
+            str(opt),
+            str({
+                'security': [],
+                'call': {'model': DIRECT}
+                }))
         _remote.add.assert_called_once_with(fn)
 
     @patch('gofer.decorators.Remote')
@@ -53,7 +70,14 @@ class TestRemote(TestCase):
         secret = 'fedex'
         remote(secret=secret)(fn)
         opt = getattr(fn, NAME)
-        self.assertEqual(str(opt), str({'security': [('secret', {'secret': 'fedex'})]}))
+        self.assertEqual(
+            str(opt),
+            str({
+                'security': [
+                    ('secret', {'secret': 'fedex'})
+                ],
+                'call': {'model': DIRECT}
+                }))
         _remote.add.assert_called_once_with(fn)
 
 
@@ -65,7 +89,12 @@ class TestPam(TestCase):
         opt = getattr(fn, NAME)
         self.assertEqual(
             str(opt),
-            str({'security': [('pam', {'user': 'root', 'service': None})]}))
+            str({
+                'security': [
+                    ('pam', {'user': 'root', 'service': None})
+                ],
+                'call': {'model': DIRECT}
+                }))
 
     def test_service(self):
         def fn(): pass
@@ -73,7 +102,12 @@ class TestPam(TestCase):
         opt = getattr(fn, NAME)
         self.assertEqual(
             str(opt),
-            str({'security': [('pam', {'user': 'root', 'service': 'find'})]}))
+            str({
+                'security': [
+                    ('pam', {'user': 'root', 'service': 'find'})
+                ],
+                'call': {'model': DIRECT}
+                }))
 
 
 class TestUser(TestCase):
@@ -84,7 +118,12 @@ class TestUser(TestCase):
         opt = getattr(fn, NAME)
         self.assertEqual(
             str(opt),
-            str({'security': [('pam', {'user': 'root', 'service': None})]}))
+            str({
+                'security': [
+                    ('pam', {'user': 'root', 'service': None})
+                ],
+                'call': {'model': DIRECT}
+                }))
 
 
 class TestAction(TestCase):


### PR DESCRIPTION
The *model* can be specified using the *remote* decorator as:
```
from gofer.rmi.model import FORK

@remote(model=FORK)
def bark(self):
    return 'hello master'
```

The `direct` model calls the method within the `goferd` process.
The `fork` model calls the method in a child process spawned for each call.

Testing still in progress:
- [x] memory and *fildes* leaks.
- [x] child process leaks when `goferd` is restarted.
- [x] cancel testing.
- [x] python 2.4 testing EL5 compat

Note: multiprocessing added in python 2.6. 