### PR TITLE
Add direct and fork decorators.

### DIFF
--- a/docs/sphinx/decorators.rst
+++ b/docs/sphinx/decorators.rst
@@ -42,6 +42,27 @@ Options:
     - default: direct
     - note: Added in 2.8
 
+
+@direct
+-------
+
+The *direct* decorator is used to designate a function to use the *direct* invocation model.
+With this model, the function is invoked within the goferd process.
+
+Added: 2.8
+
+
+@fork
+-----
+
+The *fork* decorator is used to designate a function to use the *fork* invocation model.
+With this model, the function is invoked in a newly spawned child process.  This model may be used
+to insulate the goferd process from unwanted side effects such as memory and filedes leaks,
+global configuration changes and core dumps.
+
+Added: 2.8
+
+
 @pam
 ----
 

--- a/docs/sphinx/notes.rst
+++ b/docs/sphinx/notes.rst
@@ -276,7 +276,7 @@ Notes:
   potentially introduced by plugins (or code used by plugins). When using the ``fork``
   model, RMI cancellation is implemented by killing the child process.  As a result
   cancellation is certain and immediate regardless of whether cancellation is implemented
-  by the method.
+  by the method.  See: ``direct`` and ``fork`` decorators.
 
 Fixes:
 

--- a/src/gofer/decorators.py
+++ b/src/gofer/decorators.py
@@ -17,7 +17,7 @@ import inspect
 
 from gofer import NAME, Options
 from gofer.rmi.decorator import Remote
-from gofer.rmi.model import DIRECT, valid_model
+from gofer.rmi.model import DIRECT, FORK, valid_model
 from gofer.agent.decorator import Actions
 from gofer.agent.decorator import Delegate
 
@@ -66,6 +66,30 @@ def remote(fx=None, model=DIRECT, secret=None):
         return inner(fx)
     else:
         return inner
+
+
+def direct(fn):
+    """
+    The *direct* decorator used to specify the *direct* model.
+    :param fn: The function being decorated.
+    :type fn: function
+    :return: The decorated function.
+    """
+    opt = options(fn)
+    opt.call.model = valid_model(DIRECT)
+    return fn
+
+
+def fork(fn):
+    """
+    The *fork* decorator used to specify the *fork* model.
+    :param fn: The function being decorated.
+    :type fn: function
+    :return: The decorated function.
+    """
+    opt = options(fn)
+    opt.call.model = valid_model(FORK)
+    return fn
 
 
 def pam(user, service=None):

--- a/test/functional/plugins/forked.py
+++ b/test/functional/plugins/forked.py
@@ -1,8 +1,7 @@
 from logging import getLogger
 from time import sleep
 
-from gofer.decorators import remote
-from gofer.rmi.model import FORK
+from gofer.decorators import remote, fork, FORK
 from gofer.agent.plugin import Plugin
 from gofer.agent.rmi import Context
 
@@ -13,11 +12,13 @@ log = getLogger(__name__)
 
 class Panther(object):
 
-    @remote(model=FORK)
+    @fork
+    @remote
     def test(self):
         return 'done'
 
-    @remote(model=FORK)
+    @fork
+    @remote
     def sleep(self, n=90):
         while n > 0:
             log.info('sleeping')
@@ -36,6 +37,7 @@ class Panther(object):
             context.progress.report()
         return 'done'
 
-    @remote(model=FORK)
+    @fork
+    @remote
     def test_exceptions(self):
         raise ValueError('That was bad')

--- a/test/unit/test_decorators.py
+++ b/test/unit/test_decorators.py
@@ -14,9 +14,9 @@ from unittest import TestCase
 from mock import patch, Mock
 
 from gofer import NAME
-from gofer.decorators import options, remote, pam, user, action
+from gofer.decorators import options, remote, direct, fork, pam, user, action
 from gofer.decorators import load, unload, initializer
-from gofer.decorators import DIRECT
+from gofer.decorators import DIRECT, FORK
 
 
 class Function(object):
@@ -65,6 +65,19 @@ class TestRemote(TestCase):
         _remote.add.assert_called_once_with(fn)
 
     @patch('gofer.decorators.Remote')
+    def test_model(self, _remote):
+        def fn(): pass
+        remote(fn, model=FORK)
+        opt = getattr(fn, NAME)
+        self.assertEqual(
+            str(opt),
+            str({
+                'security': [],
+                'call': {'model': FORK}
+                }))
+        _remote.add.assert_called_once_with(fn)
+
+    @patch('gofer.decorators.Remote')
     def test_secret(self, _remote):
         def fn(): pass
         secret = 'fedex'
@@ -79,6 +92,34 @@ class TestRemote(TestCase):
                 'call': {'model': DIRECT}
                 }))
         _remote.add.assert_called_once_with(fn)
+
+
+class TestDirect(TestCase):
+
+    def test_call(self):
+        def fn(): pass
+        direct(fn)
+        opt = getattr(fn, NAME)
+        self.assertEqual(
+            str(opt),
+            str({
+                'security': [],
+                'call': {'model': DIRECT}
+                }))
+
+
+class TestFork(TestCase):
+
+    def test_call(self):
+        def fn(): pass
+        fork(fn)
+        opt = getattr(fn, NAME)
+        self.assertEqual(
+            str(opt),
+            str({
+                'security': [],
+                'call': {'model': FORK}
+                }))
 
 
 class TestPam(TestCase):


### PR DESCRIPTION
The `model` parameter in remote is replaced with ``direct`` and ``fork`` decorators.