### PR TITLE
Fix IOError errno=EAGAIN on EL5.

### DIFF
--- a/src/gofer/rmi/model/protocol.py
+++ b/src/gofer/rmi/model/protocol.py
@@ -66,6 +66,7 @@ class Message(object):
         :rtype: Message
         """
         try:
+            pipe.poll(None)
             message = pipe.recv()
             if not message:
                 raise EOFError()

--- a/test/unit/rmi/model/test_child.py
+++ b/test/unit/rmi/model/test_child.py
@@ -13,6 +13,7 @@ class Pipe(object):
 
     def __init__(self):
         self.pipe = []
+        self.poll = Mock()
 
     def send(self, thing):
         self.pipe.append(thing)

--- a/test/unit/rmi/model/test_protocol.py
+++ b/test/unit/rmi/model/test_protocol.py
@@ -11,6 +11,7 @@ class Pipe(object):
 
     def __init__(self):
         self.pipe = []
+        self.poll = Mock()
 
     def send(self, thing):
         self.pipe.append(thing)
@@ -46,6 +47,7 @@ class TestMessage(TestCase):
         p = Person.read(pipe)
 
         # validation
+        pipe.poll.assert_called_once_with(None)
         self.assertTrue(isinstance(p, Person))
         self.assertEqual(p.name, p_in.name)
         self.assertEqual(p.age, p_in.age)


### PR DESCRIPTION
Seems a difference in sockets/pipes between python (or multiprocessing) on EL5 causes `IOError` with errno=`EAGAIN` on pipe.recv().  The `Pipe` is actually a `Conneciton`.  The pipe is behaving as though it was non-blocking.  Using `Connection.poll(None)` safeguards the *recv()* in all cases.