### PR TITLE
Replace multiprocessing with simpler module.

### DIFF
--- a/gofer.spec
+++ b/gofer.spec
@@ -139,7 +139,6 @@ Requires: python-ctypes
 Requires: python-simplejson
 Requires: python-hashlib
 Requires: python-uuid
-Requires: python-multiprocessing
 %endif
 
 %description -n python-%{name}

--- a/src/gofer/mp.py
+++ b/src/gofer/mp.py
@@ -1,0 +1,228 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
+import os
+import pickle
+
+from signal import SIGKILL
+
+try:
+    from select import epoll, EPOLLIN, EPOLLHUP
+except ImportError:
+    from select import poll as epoll, POLLIN as EPOLLIN, POLLHUP as EPOLLHUP
+
+
+class Process(object):
+    """
+    Linux Process.
+    :ivar main: The process main.
+    :type main: callable
+    :ivar args: Argument list.
+    :type args: tuple
+    :ivar kwargs: Keyword arguments.
+    :type kwargs: dict
+    :ivar pid: The process ID.
+    :type pid: int
+    """
+
+    def __init__(self, main, *args, **kwargs):
+        self.main = main
+        self.args = args
+        self.kwargs = kwargs
+        self.pid = 0
+
+    def start(self):
+        """
+        Start the process by forking then calling run().
+        """
+        pid = os.fork()
+        if pid == 0:
+            self.pid = os.getpid()
+            self.run()
+        else:
+            self.pid = pid
+
+    def run(self):
+        """
+        Call main() then terminate the process.
+        """
+        try:
+            self.main(*self.args, **self.kwargs)
+        finally:
+            self.terminate()
+
+    def terminate(self):
+        """
+        Terminate the process.
+        """
+        if self.pid:
+            os.kill(self.pid, SIGKILL)
+
+    def wait(self):
+        """
+        Wait for the process to terminate.
+        Swallows raised exceptions.
+        """
+        try:
+            return os.waitpid(self.pid, 0)
+        except OSError:
+            pass
+
+
+class Pipe(object):
+    """
+    Inter-process pipe.
+    :ivar reader: The *read* end of the pipe.
+    :type reader: Reader
+    :ivar writer: The write end of the pipe.
+    :ivar writer: Writer
+    """
+
+    @staticmethod
+    def _open():
+        """
+        Open (create) the pipe and the *reader* and *writer*.
+        :return: A tuple of: (Reader, Writer)
+        :rtype: tuple
+        """
+        read, write = os.pipe()
+        return Reader(read), Writer(write)
+
+    def __init__(self):
+        """
+        Create the pipe.
+        """
+        self.reader, self.writer = Pipe._open()
+
+    def close(self):
+        """
+        Close the pipe.
+        """
+        for endpoint in (self.reader, self.writer):
+            endpoint.close()
+
+    def poll(self):
+        """
+        Poll the *reader*.
+        Blocks until data is available to be read or the
+        writing end has been closed.
+        """
+        self.reader.poll()
+
+    def get(self):
+        """
+        Read the next pickled object from the pipe.
+        :return: The next read message.
+        :rtype: object
+        """
+        return self.reader.get()
+
+    def put(self, thing):
+        """
+        Pickle and write the object into the pipe.
+        :param thing: An object.
+        :type thing: any
+        """
+        self.writer.put(thing)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *unused):
+        self.close()
+
+
+class Endpoint(object):
+    """
+    A Pipe endpoint.
+    :ivar fd: An open pipe file descriptor.
+    :type fd: int
+    """
+
+    # pickled object separator
+    EOR = '\x1E'
+
+    def __init__(self, fd):
+        """
+        :param fd: An open pipe file descriptor.
+        :type fd: int
+        """
+        self.fd = fd
+
+    def close(self):
+        """
+        Close the associated file descriptor.
+        Swallows raised exceptions.
+        """
+        try:
+            os.close(self.fd)
+        except:
+            pass
+
+
+class Reader(Endpoint):
+    """
+    The *reading* end of a Pipe.
+    :ivar epoll: A file descriptor polling object.
+    :type epoll: socket.poll
+    """
+
+    def __init__(self, fd):
+        """
+        :param fd: An open pipe file descriptor.
+        :type fd: int
+        """
+        super(Reader, self).__init__(fd)
+        self.epoll = epoll()
+        self.epoll.register(fd, EPOLLIN | EPOLLHUP)
+
+    def get(self):
+        """
+        Read the next pickled object from the pipe.
+        :return: The next read message.
+        :rtype: object
+        """
+        record = []
+        while True:
+            byte = os.read(self.fd, 1)
+            if not byte:
+                raise EOFError()
+            if byte == Endpoint.EOR:
+                break
+            record.append(byte)
+        if record:
+            return pickle.loads(''.join(record))
+        else:
+            raise EOFError()
+
+    def poll(self):
+        """
+        Blocks until data is available to be read or the
+        writing end has been closed.
+        """
+        self.epoll.poll()
+
+
+class Writer(Endpoint):
+
+    def put(self, thing):
+        """
+        Pickle and write the object into the pipe.
+        :param thing: An object.
+        :type thing: any
+        """
+        record = pickle.dumps(thing)
+        os.write(self.fd, record)
+        os.write(self.fd, Endpoint.EOR)

--- a/src/gofer/rmi/model/child.py
+++ b/src/gofer/rmi/model/child.py
@@ -37,7 +37,7 @@ class Call(protocol.Call):
           - Send result: retval, progress, raised exception.
         All output is sent to the parent using the inter-process pipe.
         :param pipe: A message pipe.
-        :type  pipe: multiprocessing.Connection
+        :type  pipe: gofer.mp.Writer
         """
         try:
             context = Context.current()
@@ -56,7 +56,7 @@ class Progress(object):
     """
     Provides progress reporting to the parent through the pipe.
     :ivar pipe: A message pipe.
-    :type pipe: multiprocessing.Connection
+    :type pipe: gofer.mp.Writer
     :ivar total: The total work units.
     :type total: int
     :ivar completed: The completed work units.
@@ -68,7 +68,7 @@ class Progress(object):
     def __init__(self, pipe):
         """
         :param pipe: A message pipe.
-        :type  pipe: multiprocessing.Connection
+        :type  pipe: gofer.mp.Writer
         """
         self.pipe = pipe
         self.total = 0

--- a/test/functional/plugins/forked.py
+++ b/test/functional/plugins/forked.py
@@ -1,3 +1,5 @@
+import os
+
 from logging import getLogger
 from time import sleep
 
@@ -41,3 +43,9 @@ class Panther(object):
     @remote
     def test_exceptions(self):
         raise ValueError('That was bad')
+
+    @fork
+    @remote
+    def test_suicide(self):
+        log.info('Goodbye cruel world')
+        os.kill(os.getpid(), 9)

--- a/test/functional/server.py
+++ b/test/functional/server.py
@@ -456,6 +456,7 @@ def test_forked(exit=0, with_cancel=1):
     panther = agent.Panther()
     print 'forked test(): %s' % panther.test()
     print 'forked test_progress(): %s' % panther.test_progress()
+    print 'forked test_suicide(): %s' % panther.test_suicide()
     try:
         panther.test_exceptions()
     except ValueError:

--- a/test/unit/rmi/model/test_child.py
+++ b/test/unit/rmi/model/test_child.py
@@ -1,3 +1,18 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
 from unittest import TestCase
 
 from mock import patch, Mock
@@ -15,10 +30,10 @@ class Pipe(object):
         self.pipe = []
         self.poll = Mock()
 
-    def send(self, thing):
+    def put(self, thing):
         self.pipe.append(thing)
 
-    def recv(self):
+    def get(self):
         return self.pipe.pop()
 
 

--- a/test/unit/rmi/model/test_direct.py
+++ b/test/unit/rmi/model/test_direct.py
@@ -1,3 +1,18 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
 from unittest import TestCase
 
 from mock import Mock

--- a/test/unit/rmi/model/test_fork.py
+++ b/test/unit/rmi/model/test_fork.py
@@ -1,3 +1,18 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
 from unittest import TestCase
 
 from mock import Mock

--- a/test/unit/rmi/model/test_model.py
+++ b/test/unit/rmi/model/test_model.py
@@ -1,3 +1,18 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
 from unittest import TestCase
 
 from gofer.rmi.model import ALL, valid_model

--- a/test/unit/rmi/model/test_protocol.py
+++ b/test/unit/rmi/model/test_protocol.py
@@ -1,3 +1,18 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
 from unittest import TestCase
 
 from mock import Mock
@@ -13,10 +28,10 @@ class Pipe(object):
         self.pipe = []
         self.poll = Mock()
 
-    def send(self, thing):
+    def put(self, thing):
         self.pipe.append(thing)
 
-    def recv(self):
+    def get(self):
         return self.pipe.pop()
 
 
@@ -47,14 +62,14 @@ class TestMessage(TestCase):
         p = Person.read(pipe)
 
         # validation
-        pipe.poll.assert_called_once_with(None)
+        pipe.poll.assert_called_once_with()
         self.assertTrue(isinstance(p, Person))
         self.assertEqual(p.name, p_in.name)
         self.assertEqual(p.age, p_in.age)
 
     def test_read_end(self):
         pipe = Pipe()
-        pipe.send(0)
+        pipe.put(0)
         self.assertRaises(End, Person.read, pipe)
 
 

--- a/test/unit/test_mp.py
+++ b/test/unit/test_mp.py
@@ -1,0 +1,236 @@
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU Lesser General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (LGPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of LGPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.0.txt.
+#
+# Jeff Ortel <jortel@redhat.com>
+#
+
+from unittest import TestCase
+
+from mock import Mock, patch
+
+from gofer.mp import Process, Pipe, Endpoint, Reader, Writer
+from gofer.mp import EPOLLIN, EPOLLHUP
+
+
+MODULE = 'gofer.mp'
+
+
+class Thing(object):
+
+    def __eq__(self, other):
+        return isinstance(other, Thing) and self.__dict__ == other.__dict__
+
+
+class TestProcess(TestCase):
+
+    def test_init(self):
+        main = Mock()
+        args = (1, 2)
+        kwargs = {'a': 3, 'b': 4}
+
+        # test
+        p = Process(main, *args, **kwargs)
+
+        # validation
+        self.assertEqual(p.main, main)
+        self.assertEqual(p.args, (1, 2))
+        self.assertEqual(p.kwargs, {'a': 3, 'b': 4})
+
+    @patch('os.fork')
+    @patch(MODULE + '.Process.run')
+    def test_start_child(self, run, fork):
+        fork.return_value = 0
+        p = Process(Mock())
+
+        # test
+        p.start()
+
+        # validation
+        fork.assert_called_once_with()
+        run.assert_called_once_with()
+
+    @patch('os.fork')
+    @patch(MODULE + '.Process.run')
+    def test_start_parent(self, run, fork):
+        fork.return_value = 1234
+        p = Process(Mock())
+
+        # test
+        p.start()
+
+        # validation
+        fork.assert_called_once_with()
+        self.assertFalse(run.called)
+        self.assertEqual(p.pid, fork.return_value)
+
+    def test_run(self):
+        main = Mock()
+        args = (1, 2)
+        kwargs = {'a': 3, 'b': 4}
+
+        # test
+        p = Process(main, *args, **kwargs)
+        p.run()
+
+        # validation
+        p.main.assert_called_once_with(*args, **kwargs)
+
+    @patch('os.kill')
+    def test_terminate(self, kill):
+        p = Process(Mock())
+        p.pid = 1234
+        p.terminate()
+        kill.assert_called_once_with(p.pid, 9)
+
+    @patch('os.kill')
+    def test_terminate_not_forked(self, kill):
+        p = Process(Mock())
+        p.terminate()
+        self.assertFalse(kill.called)
+
+    @patch('os.waitpid')
+    def test_wait(self, wait):
+        p = Process(Mock())
+        p.wait()
+        wait.assert_called_once_with(p.pid, 0)
+
+    @patch('os.waitpid')
+    def test_wait_error(self, wait):
+        wait.side_effect = OSError()
+        p = Process(Mock())
+        p.wait()
+        wait.assert_called_once_with(p.pid, 0)
+
+
+class TestPipe(TestCase):
+
+    @patch('os.pipe')
+    def test_open(self, pipe):
+        pipe.return_value = 0, 1
+        reader, writer = Pipe._open()
+        self.assertEqual(reader.fd, 0)
+        self.assertEqual(writer.fd, 1)
+
+    @patch(MODULE + '.Pipe._open')
+    def test_init(self, _open):
+        _open.return_value = Reader(0), Writer(1)
+        p = Pipe()
+        self.assertTrue(isinstance(p.reader, Reader))
+        self.assertTrue(isinstance(p.writer, Writer))
+        self.assertEqual(p.reader.fd, 0)
+        self.assertEqual(p.writer.fd, 1)
+
+    @patch(MODULE + '.Pipe._open')
+    def test_close(self, _open):
+        _open.return_value = Mock(), Mock()
+        p = Pipe()
+        p.close()
+        _open.return_value[0].close.assert_called_once_with()
+        _open.return_value[1].close.assert_called_once_with()
+
+    @patch(MODULE + '.Pipe._open')
+    def test_poll(self, _open):
+        _open.return_value = Mock(), Mock()
+        p = Pipe()
+        p.poll()
+        _open.return_value[0].poll.assert_called_once_with()
+
+    @patch(MODULE + '.Pipe._open')
+    def test_get(self, _open):
+        _open.return_value = Mock(), Mock()
+        p = Pipe()
+        thing = p.get()
+        _open.return_value[0].get.assert_called_once_with()
+        self.assertEqual(thing, _open.return_value[0].get.return_value)
+
+    @patch(MODULE + '.Pipe._open')
+    def test_put(self, _open):
+        _open.return_value = Mock(), Mock()
+        thing = Thing()
+        p = Pipe()
+        p.put(thing)
+        _open.return_value[1].put.assert_called_once_with(thing)
+
+    @patch(MODULE + '.Pipe._open')
+    def test_enter(self, _open):
+        _open.return_value = Mock(), Mock()
+        p = Pipe()
+        self.assertEqual(p.__enter__(), p)
+
+    @patch(MODULE + '.Pipe.close')
+    @patch(MODULE + '.Pipe._open')
+    def test_exit(self, _open, close):
+        _open.return_value = Mock(), Mock()
+        p = Pipe()
+        p.__exit__()
+        close.assert_called_once_with()
+
+
+class TestEndpoint(TestCase):
+
+    def test_init(self):
+        fd = 18
+        endpoint = Endpoint(fd)
+        self.assertEqual(endpoint.fd, fd)
+
+    @patch('os.close')
+    def test_close(self, close):
+        endpoint = Endpoint(18)
+        endpoint.close()
+        close.assert_called_once_with(endpoint.fd)
+
+
+class TestReader(TestCase):
+
+    @patch(MODULE + '.epoll')
+    def test_init(self, epoll):
+        fd = 18
+        reader = Reader(fd)
+        self.assertEqual(reader.fd, fd)
+        self.assertEqual(reader.epoll, epoll.return_value)
+        epoll.return_value.register.assert_called_once_with(reader.fd, EPOLLIN | EPOLLHUP)
+
+    def test_write_read(self):
+        thing = Thing()
+        p = Pipe()
+        p.put(thing)
+        read = p.reader.get()
+        p.close()
+        self.assertEqual(read, thing)
+
+    def test_multiple_write_read(self):
+        things = [
+            Thing(),
+            Thing(),
+            Thing()
+        ]
+        p = Pipe()
+        for t in things:
+            p.put(t)
+        read = []
+        for _ in things:
+            read.append(p.reader.get())
+        p.close()
+        self.assertEqual(read, things)
+
+    def test_eof(self):
+        p = Pipe()
+        p.writer.close()
+        self.assertRaises(EOFError, p.reader.get)
+        p.close()
+
+    @patch(MODULE + '.epoll')
+    def test_poll(self, epoll):
+        fd = 1234
+        r = Reader(fd)
+        r.poll()
+        epoll.return_value.poll.assert_called_once_with()


### PR DESCRIPTION
The multiprocessing lib in python is intended to be a process based alternative to dispatching work to thread threads or pools.  It's a multiprocessing implementation of the threading interface.  It was introduced in python 2.6 and is not available in RHEL5 (though in EPEL5).  The rmi.model package has simple needs.  To simply fork; invoke a method and relay (pipe) progress reporting and result (retval or exception) back to the parent process.  This requires very little from multiprocessing and just needs simple fork() and pipe() stuff provided by basic python.  Very straight forward.