### PR TITLE
Apply broker model setup when NotFound is caught by the request consumer.

### DIFF
--- a/src/gofer/agent/main.py
+++ b/src/gofer/agent/main.py
@@ -107,6 +107,8 @@ def start(daemon=True):
     Agent main.
     Add recurring, time-based actions here.
     All actions must be subclass of action.Action.
+    :param daemon: The daemon flag.
+    :type daemon: bool
     """
     lock = AgentLock()
     try:
@@ -140,10 +142,13 @@ def usage():
 def start_daemon(lock):
     """
     Daemon configuration.
+    :param lock: The agent lock.
+    :type lock: AgentLock
     """
     pid = os.fork()
     if pid == 0:  # child
         os.setsid()
+        os.setpgrp()
         os.chdir('/')
         os.close(0)
         os.close(1)

--- a/src/gofer/agent/plugin.py
+++ b/src/gofer/agent/plugin.py
@@ -33,7 +33,7 @@ from gofer.agent.whiteboard import Whiteboard
 from gofer.common import nvl, mkdir
 from gofer.common import released
 from gofer.config import Config, Graph, FileReader, get_bool, get_integer
-from gofer.messaging import Document, Connector, Node, Queue, Exchange
+from gofer.messaging import Document, Connector, Queue, Exchange
 from gofer.messaging import NotFound
 from gofer.rmi.consumer import RequestConsumer
 from gofer.rmi.decorator import Remote
@@ -360,8 +360,7 @@ class Plugin(object):
         self.refresh()
         model = BrokerModel(self)
         model.setup()
-        node = Node(model.queue)
-        consumer = RequestConsumer(node, self)
+        consumer = RequestConsumer(self, model)
         consumer.authenticator = self.authenticator
         consumer.start()
         self.consumer = consumer

--- a/src/gofer/messaging/__init__.py
+++ b/src/gofer/messaging/__init__.py
@@ -19,9 +19,6 @@ from gofer.messaging.auth import \
     Authenticator, \
     ValidationFailed
 
-from gofer.messaging.consumer import \
-    Consumer
-
 from gofer.messaging.adapter import \
     URL, \
     SSL, \
@@ -40,3 +37,6 @@ from gofer.messaging.adapter import \
     Sender, \
     Producer, \
     NotFound
+
+from gofer.messaging.consumer import \
+    Consumer

--- a/test/functional/plugins/testplugin.py
+++ b/test/functional/plugins/testplugin.py
@@ -13,6 +13,7 @@
 #
 # Jeff Ortel <jortel@redhat.com>
 #
+import os
 
 from time import sleep
 from hashlib import sha256
@@ -23,6 +24,7 @@ from gofer.agent.plugin import Plugin
 from gofer.agent.rmi import Context
 from gofer.messaging.auth import Authenticator, ValidationFailed
 from gofer.messaging import Producer
+from gofer.rmi.shell import Shell
 
 log = getLogger(__name__)
 plugin = Plugin.find(__name__)
@@ -270,6 +272,15 @@ class Lion(object):
     @remote
     def roar(self):
         return 'Lion says ROAR!'
+
+
+class Zombie(object):
+
+    @remote
+    def sleep(self, n):
+        log.info('PID: %s', os.getpid())
+        shell = Shell()
+        shell.run('sleep', str(n))
 
 
 class Heartbeat:

--- a/test/functional/server.py
+++ b/test/functional/server.py
@@ -179,7 +179,7 @@ def test_performance():
         dog.bark('performance!')
     t.stop()
     print 'total=%s, percall=%f (ms)' % (t, (t.duration()/N)*1000)
-    #sys.exit(0)
+    # sys.exit(0)
     # ASYNCHRONOUS
     agent = Agent(wait=0)
     dog = agent.Dog()
@@ -207,6 +207,13 @@ def test_memory():
         print 'tested %d' % n
     t.stop()
     print 'total=%s, percall=%f (ms)' % (t, (t.duration()/N)*1000)
+    sys.exit(0)
+
+
+def test_zombie():
+    agent = Agent()
+    zombie = agent.Zombie()
+    zombie.sleep(240)
     sys.exit(0)
 
 
@@ -472,6 +479,8 @@ if __name__ == '__main__':
     Agent.url = url
     Agent.address = address
     Agent.base_options['authenticator'] = authenticator
+
+    # test_zombie()
 
     # test_memory()
 

--- a/test/unit/agent/test_plugin.py
+++ b/test/unit/agent/test_plugin.py
@@ -294,13 +294,12 @@ class TestPlugin(TestCase):
         self.assertEqual(connector.ssl.client_certificate, descriptor.messaging.clientcert)
         self.assertEqual(connector.ssl.host_validation, descriptor.messaging.host_validation)
 
-    @patch('gofer.agent.plugin.Node')
     @patch('gofer.agent.plugin.RequestConsumer')
     @patch('gofer.agent.plugin.BrokerModel')
     @patch('gofer.agent.plugin.ThreadPool')
     @patch('gofer.agent.plugin.Scheduler', Mock())
     @patch('gofer.agent.plugin.Whiteboard', Mock())
-    def test_attach(self, pool, model, consumer, node):
+    def test_attach(self, pool, model, consumer):
         queue = 'test'
         descriptor = Mock(main=Mock(threads=4))
         pool.return_value.run.side_effect = lambda fn: fn()
@@ -317,8 +316,7 @@ class TestPlugin(TestCase):
         plugin.detach.assert_called_once_with(False)
         model.assert_called_with(plugin)
         model.return_value.setup.assert_called_once_with()
-        node.assert_called_once_with(queue)
-        consumer.assert_called_once_with(node.return_value, plugin)
+        consumer.assert_called_once_with(plugin, model.return_value)
         consumer = consumer.return_value
         consumer.start.assert_called_once_with()
         self.assertEqual(consumer.authenticator, plugin.authenticator)


### PR DESCRIPTION
The broker model _setup_ is performed as part of starting the plugin. However, if the RequestConsumer catches a NotFound exception when trying to fetch messages, broker model setup is not part of the repair process. This patch adds the concept of Consumer.repair() which provides the RequestConsumer the opportunity to repeat the broker model setup. Assuming the plugin configuration has enabled model management, the queue could be re-declared.

[1] The _broker model_ refers to the AMQP exchanges, queues and binding queues to exchanges.
