### PR TITLE
Support soft plugin shutdown.

### DIFF
--- a/src/gofer/agent/builtin.py
+++ b/src/gofer/agent/builtin.py
@@ -151,6 +151,12 @@ class Builtin(object):
         """
         return self.dispatcher.dispatch(request)
 
+    def start(self):
+        """
+        Start the plugin.
+        """
+        self.pool.start()
+
     def shutdown(self):
         """
         Shutdown the plugin.

--- a/src/gofer/agent/rmi.py
+++ b/src/gofer/agent/rmi.py
@@ -36,7 +36,7 @@ class Task:
     :type ts: float
     """
 
-    context = Local()
+    context = Local(sn=None, progress=None, cancelled=None)
 
     @staticmethod
     def _producer(plugin):
@@ -89,8 +89,8 @@ class Task:
         try:
             self.send_started(request)
             result = self.plugin.dispatch(request)
-            self.commit()
             self.send_reply(request, result)
+            self.commit()
         finally:
             self.context.sn = None
             self.context.progress = None
@@ -222,6 +222,7 @@ class Scheduler(Thread):
         Read the pending queue and dispatch requests
         to the plugin thread pool.
         """
+        self.builtin.start()
         while not Thread.aborted():
             try:
                 request = self.pending.get()

--- a/src/gofer/common.py
+++ b/src/gofer/common.py
@@ -17,7 +17,8 @@ import os
 import inspect
 import errno
 
-from threading import local as Local
+from copy import copy
+from threading import local as _Local
 from threading import Thread as _Thread
 from threading import currentThread as current_thread
 from threading import Event, RLock
@@ -124,13 +125,23 @@ class Thread(_Thread):
         setattr(self, Thread.ABORT, Event())
 
     @staticmethod
+    def current():
+        """
+        Get the current thread.
+
+        :return: The current thread.
+        :rtype: _Thread
+        """
+        return current_thread()
+
+    @staticmethod
     def aborted():
         """
         Check abort event.
         :return: True if raised.
         :rtype: bool
         """
-        thread = current_thread()
+        thread = Thread.current()
         try:
             event = getattr(thread, Thread.ABORT)
         except AttributeError:
@@ -146,6 +157,37 @@ class Thread(_Thread):
         """
         aborted = getattr(self, Thread.ABORT)
         aborted.set()
+
+
+class Local(object):
+    """
+    Thread local object.
+    Provides an interface whereby attributes can have a default.
+    The AttributeError is only raised when the local object does not
+    have the attribute set and not default has been specified.
+    """
+
+    KEY = 'storage'
+    DEFAULT = 'default'
+
+    def __init__(self, **default):
+        self.__dict__[Local.KEY] = _Local()
+        self.__dict__[Local.DEFAULT] = default
+
+    def __setattr__(self, name, value):
+        setattr(self.__dict__[Local.KEY], name, value)
+
+    def __getattr__(self, name):
+        try:
+            return getattr(self.__dict__[Local.KEY], name)
+        except AttributeError, nf:
+            d = self.__dict__[Local.DEFAULT].get(name)
+            if d is not None:
+                d = copy(d)
+                setattr(self.__dict__[Local.KEY], name, d)
+                return d
+            else:
+                raise nf
 
 
 class Singleton(type):
@@ -183,21 +225,16 @@ class ThreadSingleton(type):
     usage: __metaclass__ = ThreadSingleton
     """
 
-    _inst = Local()
+    _inst = Local(all={})
 
     @staticmethod
     def all():
-        try:
-            return ThreadSingleton._inst.d
-        except AttributeError:
-            d = {}
-            ThreadSingleton._inst.d = d
-            return d
+        return ThreadSingleton._inst.all
 
     @staticmethod
     def purge():
         d = ThreadSingleton.all()
-        ThreadSingleton._inst.d = {}
+        ThreadSingleton._inst.all = {}
         return d.values()
 
     def __call__(cls, *args, **kwargs):

--- a/test/functional/plugins/testplugin.py
+++ b/test/functional/plugins/testplugin.py
@@ -283,6 +283,32 @@ class Zombie(object):
         shell.run('sleep', str(n))
 
 
+class PluginShutdown(object):
+    """
+    Test a soft shutdown called from a plugin.
+    Designed to support an agent restart initiated by plugin RMI.
+
+    Note: THIS WILL LEAVE THE PLUGIN DEAD!!
+    """
+
+    PATH = '/tmp/plugin-shutdown'
+
+    @remote
+    def request(self):
+        with open(PluginShutdown.PATH, 'w+'):
+            pass
+        sleep(10)
+
+    @action(seconds=5)
+    def apply(self):
+        if not os.path.exists(PluginShutdown.PATH):
+            return
+        log.info('plugin-shutdown, requested')
+        plugin.shutdown()
+        log.info('plugin-shutdown, FINISHED')
+        os.unlink(PluginShutdown.PATH)
+
+
 class Heartbeat:
     """
     Provide agent heartbeat.

--- a/test/functional/server.py
+++ b/test/functional/server.py
@@ -448,6 +448,14 @@ def test_cancel():
     sys.exit(0)
 
 
+def test_plugin_shutdown(exit=0):
+    agent = Agent()
+    shutdown = agent.PluginShutdown()
+    shutdown.request()
+    if exit:
+        sys.exit(0)
+
+
 def get_options():
     parser = OptionParser(option_class=ListOption)
     parser.add_option('-r', '--address', default='xyz', help='address')
@@ -480,6 +488,7 @@ if __name__ == '__main__':
     Agent.address = address
     Agent.base_options['authenticator'] = authenticator
 
+    # test_plugin_shutdown(1)
     # test_zombie()
 
     # test_memory()

--- a/test/integration/test_theadpool.py
+++ b/test/integration/test_theadpool.py
@@ -46,6 +46,7 @@ def fn2(n, results):
 def test(calls=100):
     results = []
     pool = ThreadPool(9)
+    pool.start()
     for n in range(calls):
         pool.run(fn1, n, results)
     while len(results) < calls:

--- a/test/unit/agent/test_builtin.py
+++ b/test/unit/agent/test_builtin.py
@@ -125,6 +125,13 @@ class TestBuiltin(TestCase):
         self.assertEqual(result, builtin.dispatcher.dispatch.return_value)
 
     @patch('gofer.agent.builtin.ThreadPool')
+    def test_start(self, pool):
+        plugin = Mock(container=Mock())
+        builtin = Builtin(plugin)
+        builtin.start()
+        pool.return_value.start.assert_called_once_with()
+
+    @patch('gofer.agent.builtin.ThreadPool')
     def test_shutdown(self, pool):
         plugin = Mock(container=Mock())
         builtin = Builtin(plugin)

--- a/test/unit/agent/test_plugin.py
+++ b/test/unit/agent/test_plugin.py
@@ -242,7 +242,7 @@ class TestPlugin(TestCase):
         plugin.detach.assert_called_once_with(False)
         scheduler.return_value.shutdown.assert_called_once_with()
         scheduler.return_value.join.assert_called_once_with()
-        pool.return_value.shutdown.assert_called_once_with()
+        pool.return_value.shutdown.assert_called_once_with(hard=False)
 
     @patch('gofer.agent.plugin.Scheduler')
     @patch('gofer.agent.plugin.ThreadPool')


### PR DESCRIPTION
The `ThreadPool` simplified to using a single queue and added support for both *soft* or *hard* shutdown.  The plugin updated to also support both *soft* or *hard* with the default behavior change to *soft*.  This means that plugin unload/reload *could* be delayed by messaging issues.  This might be more appropriate but not sure.  Aborting the threads could result in RMI finishing without reply to caller.

This might not be needed on 2.7 and likely rebased to master.