### PR TITLE
Support soft plugin shutdown.

### DIFF
--- a/src/gofer/agent/builtin.py
+++ b/src/gofer/agent/builtin.py
@@ -151,6 +151,12 @@ class Builtin(object):
         """
         return self.dispatcher.dispatch(request)
 
+    def start(self):
+        """
+        Start the plugin.
+        """
+        self.pool.start()
+
     def shutdown(self):
         """
         Shutdown the plugin.

--- a/src/gofer/agent/rmi.py
+++ b/src/gofer/agent/rmi.py
@@ -88,8 +88,8 @@ class Task(object):
             self.producer = producer
             self.send_started(request)
             result = self.plugin.dispatch(request)
-            self.commit()
             self.send_reply(request, result)
+            self.commit()
         finally:
             producer.close()
             Context.set()
@@ -219,6 +219,7 @@ class Scheduler(Thread):
         Read the pending queue and dispatch requests
         to the plugin thread pool.
         """
+        self.builtin.start()
         while not Thread.aborted():
             try:
                 request = self.pending.get()

--- a/src/gofer/rmi/context.py
+++ b/src/gofer/rmi/context.py
@@ -34,7 +34,7 @@ class Context(object):
     :type cancelled: Cancelled
     """
 
-    _current = Local()
+    _current = Local(sn=None, progress=None, cancelled=None)
 
     @staticmethod
     def set(context=None):

--- a/test/functional/plugins/testplugin.py
+++ b/test/functional/plugins/testplugin.py
@@ -282,6 +282,32 @@ class Zombie(object):
         shell.run('sleep', str(n))
 
 
+class PluginShutdown(object):
+    """
+    Test a soft shutdown called from a plugin.
+    Designed to support an agent restart initiated by plugin RMI.
+
+    Note: THIS WILL LEAVE THE PLUGIN DEAD!!
+    """
+
+    PATH = '/tmp/plugin-shutdown'
+
+    @remote
+    def request(self):
+        with open(PluginShutdown.PATH, 'w+'):
+            pass
+        sleep(10)
+
+    @action(seconds=5)
+    def apply(self):
+        if not os.path.exists(PluginShutdown.PATH):
+            return
+        log.info('plugin-shutdown, requested')
+        plugin.shutdown()
+        log.info('plugin-shutdown, FINISHED')
+        os.unlink(PluginShutdown.PATH)
+
+
 class Heartbeat:
     """
     Provide agent heartbeat.

--- a/test/functional/server.py
+++ b/test/functional/server.py
@@ -473,6 +473,14 @@ def test_forked(exit=0, with_cancel=1):
         sys.exit(0)
 
 
+def test_plugin_shutdown(exit=0):
+    agent = Agent()
+    shutdown = agent.PluginShutdown()
+    shutdown.request()
+    if exit:
+        sys.exit(0)
+
+
 def get_options():
     parser = OptionParser(option_class=ListOption)
     parser.add_option('-r', '--address', default='xyz', help='address')
@@ -505,6 +513,7 @@ if __name__ == '__main__':
     Agent.address = address
     Agent.base_options['authenticator'] = authenticator
 
+    # test_plugin_shutdown(1)
     # test_zombie()
     # test_memory()
     test_forked()

--- a/test/integration/test_theadpool.py
+++ b/test/integration/test_theadpool.py
@@ -46,6 +46,7 @@ def fn2(n, results):
 def test(calls=100):
     results = []
     pool = ThreadPool(9)
+    pool.start()
     for n in range(calls):
         pool.run(fn1, n, results)
     while len(results) < calls:

--- a/test/unit/agent/test_builtin.py
+++ b/test/unit/agent/test_builtin.py
@@ -125,6 +125,13 @@ class TestBuiltin(TestCase):
         self.assertEqual(result, builtin.dispatcher.dispatch.return_value)
 
     @patch('gofer.agent.builtin.ThreadPool')
+    def test_start(self, pool):
+        plugin = Mock(container=Mock())
+        builtin = Builtin(plugin)
+        builtin.start()
+        pool.return_value.start.assert_called_once_with()
+
+    @patch('gofer.agent.builtin.ThreadPool')
     def test_shutdown(self, pool):
         plugin = Mock(container=Mock())
         builtin = Builtin(plugin)

--- a/test/unit/agent/test_plugin.py
+++ b/test/unit/agent/test_plugin.py
@@ -242,7 +242,7 @@ class TestPlugin(TestCase):
         plugin.detach.assert_called_once_with(False)
         scheduler.return_value.shutdown.assert_called_once_with()
         scheduler.return_value.join.assert_called_once_with()
-        pool.return_value.shutdown.assert_called_once_with()
+        pool.return_value.shutdown.assert_called_once_with(hard=False)
 
     @patch('gofer.agent.plugin.Scheduler')
     @patch('gofer.agent.plugin.ThreadPool')

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -21,6 +21,7 @@ from mock import Mock, patch
 from tempfile import mktemp
 
 from gofer.common import Thread as GThread
+from gofer.common import Local as GLocal
 from gofer.common import Singleton, ThreadSingleton, Options
 from gofer.common import synchronized, conditional, released
 from gofer.common import mkdir, rmdir, unlink, nvl, valid_path, new, utf8
@@ -253,6 +254,10 @@ class TestThread(TestCase):
         thread = GThread()
         event = getattr(thread, thread.ABORT)
         self.assertTrue(isinstance(event, type(Event())))
+
+    @patch('gofer.common.current_thread')
+    def test_current(self, current):
+        self.assertEqual(GThread.current(), current.return_value)
 
     @patch('gofer.common.current_thread')
     def test_aborted(self, current):
@@ -510,3 +515,44 @@ class TestList(TestCase):
         _list.remove(2)
         self.assertEqual(_list._list, [1, 3])
         self.assertEqual(list(iter(_list)), _list._list)
+
+
+class TestLocal(TestCase):
+
+    def test_getset(self):
+        l = GLocal()
+        l.name = 'john'
+        l.age = 10
+        self.assertEqual(l.name, 'john')
+        self.assertEqual(l.age, 10)
+
+        def test():
+            l.name = 'jane'
+            l.age = 44
+            self.assertEqual(l.name, 'jane')
+            self.assertEqual(l.age, 44)
+
+        t = Thread(target=test)
+        t.start()
+        t.join()
+
+        self.assertEqual(l.name, 'john')
+        self.assertEqual(l.age, 10)
+
+    def test_default(self):
+        l = GLocal(name='john', age=10, other={})
+        self.assertEqual(l.name, 'john')
+        self.assertEqual(l.age, 10)
+        self.assertEqual(l.other, {})
+
+        def test():
+            self.assertEqual(l.name, 'john')
+            self.assertEqual(l.age, 10)
+            self.assertEqual(l.other, {})
+            l.other['weight'] = 150
+
+        t = Thread(target=test)
+        t.start()
+        t.join()
+
+        self.assertEqual(l.other, {})


### PR DESCRIPTION
The `ThreadPool` simplified to using a single queue and added support for both *soft* or *hard* shutdown.  The plugin updated to also support both *soft* or *hard* with the default behavior change to *soft*.  This means that plugin unload/reload *could* be delayed by messaging issues.  This might be more appropriate but not sure.  Aborting the threads could result in RMI finishing without reply to caller.