### PR TITLE
Detect broken pipe instead of TIOCSCTTY.

### DIFF
--- a/src/gofer/agent/main.py
+++ b/src/gofer/agent/main.py
@@ -17,10 +17,8 @@ import sys
 import os
 import logging
 
-from fcntl import ioctl
 from time import sleep
 from getopt import getopt, GetoptError
-from termios import TIOCSCTTY
 
 from gofer.agent.logutil import LogHandler
 
@@ -159,8 +157,7 @@ def start_daemon(lock):
         fp = os.open('/dev/null', os.O_RDWR)
         os.dup(fp)
         os.dup(fp)
-        pty = os.openpty()
-        ioctl(pty[0], TIOCSCTTY, 0)
+        os.dup(fp)
     else:  # parent
         lock.setpid(pid)
         os.waitpid(pid, os.WNOHANG)

--- a/src/gofer/rmi/model/parent.py
+++ b/src/gofer/rmi/model/parent.py
@@ -46,7 +46,7 @@ class Call(protocol.Call):
         """
         pipe = Pipe()
         target = Target(self.method, *self.args, **self.kwargs)
-        child = Process(target, pipe.writer)
+        child = Process(target, pipe)
         monitor = Monitor(Context.current(), child)
         try:
             child.start()
@@ -173,8 +173,22 @@ class Raised(protocol.Raised):
         raise self.payload
 
 
+class Ping(protocol.Ping):
+    """
+    Called when a PING message is received.
+    """
+
+    def __call__(self):
+        """
+        The reported exception is instantiated and raised.
+        :raise Exception: always.
+        """
+        log.debug('pinged by %d', self.payload)
+
+
 # register reply message handling.
 protocol.Reply.register(Result.CODE, Result)
 protocol.Reply.register(Progress.CODE, Progress)
 protocol.Reply.register(Error.CODE, Error)
 protocol.Reply.register(Raised.CODE, Raised)
+protocol.Reply.register(Ping.CODE, Ping)

--- a/src/gofer/rmi/model/protocol.py
+++ b/src/gofer/rmi/model/protocol.py
@@ -230,3 +230,18 @@ class Raised(Reply):
         :type payload: object
         """
         super(Raised, self).__init__(self.CODE, payload)
+
+
+class Ping(Reply):
+    """
+    A PING event.
+    """
+
+    CODE = 'PING'
+
+    def __init__(self, payload):
+        """
+        :param payload: The sending process ID.
+        :type payload: int
+        """
+        super(Ping, self).__init__(self.CODE, payload)

--- a/test/functional/test_mp.py
+++ b/test/functional/test_mp.py
@@ -1,0 +1,41 @@
+from logging import basicConfig, DEBUG
+from time import sleep
+
+from gofer.rmi.context import Context
+from gofer.rmi.model.fork import Call
+
+
+class Cancelled(object):
+
+    def __call__(self):
+        return 0
+
+
+class Progress(object):
+
+    def report(self):
+        print self.__dict__
+
+
+class Thing(object):
+
+    def echo(self, n):
+        context = Context.current()
+        for x in range(n):
+            context.progress.details = 'hello {}'.format(x)
+            context.progress.report()
+            sleep(0.25)
+        return n
+
+
+def main():
+    basicConfig(level=DEBUG)
+    thing = Thing()
+    context = Context('0', Progress(), Cancelled())
+    Context.set(context)
+    call = Call(thing.echo, 10000)
+    print call()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/unit/rmi/model/test_child.py
+++ b/test/unit/rmi/model/test_child.py
@@ -17,31 +17,19 @@ from unittest import TestCase
 
 from mock import patch, Mock
 
-from gofer.rmi.model.child import Progress, Call
+from gofer.rmi.model.child import Progress, Call, ParentMonitor
 from gofer.rmi.model import protocol
+from gofer.mp import Pipe, PipeBroken
 
 
 MODULE = 'gofer.rmi.model.child'
-
-
-class Pipe(object):
-
-    def __init__(self):
-        self.pipe = []
-        self.poll = Mock()
-
-    def put(self, thing):
-        self.pipe.append(thing)
-
-    def get(self):
-        return self.pipe.pop()
 
 
 class TestProgress(TestCase):
 
     def test_report(self):
         pipe = Pipe()
-        p = Progress(pipe)
+        p = Progress(pipe.writer)
         p.total = 1
         p.completed = 2
         p.details = 'hello'
@@ -50,7 +38,7 @@ class TestProgress(TestCase):
         p.report()
 
         # validation
-        reply = protocol.Reply.read(pipe)
+        reply = protocol.Reply.read(pipe.reader)
         self.assertEqual(reply.code, protocol.Progress.CODE)
         self.assertEqual(reply.payload.total, p.total)
         self.assertEqual(reply.payload.completed, p.completed)
@@ -59,29 +47,66 @@ class TestProgress(TestCase):
 
 class TestCall(TestCase):
 
+    @patch(MODULE + '.ParentMonitor')
     @patch(MODULE + '.Context.current')
-    def test_call(self, context):
+    def test_call(self, context, monitor):
         method = Mock(return_value=18)
         pipe = Pipe()
+        pipe.reader.close = Mock()
         call = Call(method, 1, 2, a=1, b=2)
 
         # test
         call(pipe)
 
         # validation
-        reply = protocol.Reply.read(pipe)
+        pipe.reader.close.assert_called_once_with()
+        monitor.assert_called_once_with(pipe.writer)
+        monitor.return_value.start.assert_called_once_with()
+        reply = protocol.Reply.read(pipe.reader)
         self.assertTrue(isinstance(context.return_value.progress, Progress))
         self.assertEqual(reply.code, protocol.Result.CODE)
         self.assertEqual(reply.payload, method.return_value)
 
+    @patch(MODULE + '.ParentMonitor', Mock())
+    @patch(MODULE + '.Context.current', Mock())
+    def test_call_pipe_broken(self):
+        def method():
+            pass
+        pipe = Pipe()
+        call = Call(method)
+        call(pipe)
+
+    @patch(MODULE + '.ParentMonitor', Mock())
     def test_call_exception(self):
         method = Mock(side_effect=ValueError)
         pipe = Pipe()
-        call = Call(method, 1, 2, a=1, b=2)
+        pipe.reader.close = Mock()
+        call = Call(method)
 
         # test
         call(pipe)
-        reply = protocol.Reply.read(pipe)
+        reply = protocol.Reply.read(pipe.reader)
 
         # validation
         self.assertEqual(reply.code, protocol.Raised.CODE)
+
+
+class TestParentMonitor(TestCase):
+
+    @patch('sys.exit')
+    @patch(MODULE + '.Thread.aborted')
+    @patch(MODULE + '.sleep', Mock())
+    def test_run(self, aborted, _exit):
+        def fake_exit(n):
+            aborted.return_value = True
+        aborted.return_value = False
+        pipe = Mock()
+        _exit.side_effect = fake_exit
+        pipe.put.side_effect = PipeBroken
+
+        # test
+        monitor = ParentMonitor(pipe)
+        monitor.run()
+
+        # validation
+        _exit.assert_called_once_with(1)

--- a/test/unit/rmi/model/test_parent.py
+++ b/test/unit/rmi/model/test_parent.py
@@ -19,7 +19,7 @@ from mock import call, patch, Mock
 
 from gofer.rmi.model import protocol
 from gofer.rmi.model.parent import Monitor, Call
-from gofer.rmi.model.parent import Result, Progress, Error, Raised
+from gofer.rmi.model.parent import Result, Progress, Error, Raised, Ping
 
 
 MODULE = 'gofer.rmi.model.parent'
@@ -100,6 +100,11 @@ class TestReplies(TestCase):
         except ValueError, e:
             self.assertEqual(e, payload)
 
+    def test_ping(self):
+        payload = 1234
+        reply = Ping(payload)
+        reply()
+
 
 class TestCall(TestCase):
 
@@ -120,7 +125,7 @@ class TestCall(TestCase):
         pipe.assert_called_once_with()
         pipe.return_value.writer.close.assert_called_once_with()
         target.assert_called_once_with(_call.method, *_call.args, **_call.kwargs)
-        process.assert_called_once_with(target.return_value, pipe.return_value.writer)
+        process.assert_called_once_with(target.return_value, pipe.return_value)
         monitor.assert_called_once_with(context.current.return_value, process.return_value)
         monitor.return_value.start.assert_called_once_with()
         read.assert_called_once_with(pipe.return_value.reader)

--- a/test/unit/rmi/model/test_protocol.py
+++ b/test/unit/rmi/model/test_protocol.py
@@ -19,7 +19,7 @@ from mock import Mock
 
 from gofer.rmi.model.protocol import End
 from gofer.rmi.model.protocol import Message, Call, Reply
-from gofer.rmi.model.protocol import Progress, Result, Error, Raised
+from gofer.rmi.model.protocol import Progress, Result, Error, Raised, Ping
 
 
 class Pipe(object):
@@ -139,4 +139,10 @@ class TestReplies(TestCase):
         payload = Mock()
         reply = Raised(payload)
         self.assertEqual(reply.code, Raised.CODE)
+        self.assertEqual(reply.payload, payload)
+
+    def test_ping(self):
+        payload = Mock()
+        reply = Ping(payload)
+        self.assertEqual(reply.code, Ping.CODE)
         self.assertEqual(reply.payload, payload)

--- a/test/unit/test_mp.py
+++ b/test/unit/test_mp.py
@@ -17,7 +17,7 @@ from unittest import TestCase
 
 from mock import Mock, patch
 
-from gofer.mp import Process, Pipe, Endpoint, Reader, Writer
+from gofer.mp import Process, Pipe, Endpoint, Reader, Writer, PipeBroken
 from gofer.mp import EPOLLIN, EPOLLHUP
 
 
@@ -234,3 +234,12 @@ class TestReader(TestCase):
         r = Reader(fd)
         r.poll()
         epoll.return_value.poll.assert_called_once_with()
+
+
+class TestWriter(TestCase):
+
+    @patch('os.write')
+    def test_pipe_broken(self, write):
+        write.side_effect = PipeBroken
+        writer = Writer(0)
+        self.assertRaises(PipeBroken, writer.put, '')


### PR DESCRIPTION
Setting the controlling terminal to a pseudo terminal ensured that child process created by the *fork* RMI model would be killed when goferd has terminated.  However, having a controlling terminal is contrary to classic *daemon* behavior.  Instead, an in-flight RMI call will detect the main goferd (parent) process has terminated when getting the *Broken Pipe* `OSError` when writing.  Long running RMI calls not reporting progress my not detect the main goferd process has terminated until it tries to write the RMI result to the pipe.

This mainly impacts `init.d` managed services since `systemd` seems to kill child process on restart.