### PR TITLE
support root logger in agent configuration.

### DIFF
--- a/docs/sphinx/configuration.rst
+++ b/docs/sphinx/configuration.rst
@@ -27,12 +27,13 @@ Defines agent management properties.
 ---------
 
 This section sets logging properties.  Currently, the logging level can be set for each
-gofer packege as follows:
+gofer package as follows:
 
 ::
 
- <package> = <level>
+ <package>=<level>
 
+The special *root* package may be used to set the logging level for all packages.
 
 Levels (may be lower case):
 
@@ -55,8 +56,14 @@ Examples:
 ::
 
  [logging]
- agent = DEBUG
- messaging = WARNING
+ agent=DEBUG
+ messaging=WARNING
+
+
+::
+
+ [logging]
+ root=ERROR
 
 
 [pam]
@@ -157,7 +164,7 @@ This example enables messaging and defines the uuid:
 ::
 
  [main]
- enabled = 1
+ enabled=1
 
  [messaging]
  url=qpid+amqp://localhost
@@ -173,7 +180,7 @@ url and queue:
 ::
 
  [main]
- enabled = 1
+ enabled=1
  accept=*
 
 
@@ -184,7 +191,7 @@ sections to be used by the plugin:
 ::
 
  [main]
- enabled = 1
+ enabled=1
 
  [messaging]
  url=qpid+amqp://localhost
@@ -193,7 +200,7 @@ sections to be used by the plugin:
  queue=123
 
  [foobar]
- timeout = 100
+ timeout=100
 
 
 However, additional user defined sections and properties are supported and made available to

--- a/etc/gofer/agent.conf
+++ b/etc/gofer/agent.conf
@@ -10,8 +10,10 @@
 #      The port number the manager listens on.
 #
 # [logging]
-#   <module>
-#      Logging level
+#   <package>
+#      Set the logging level.  Eg: gofer.agent=debug.
+#      The 'root' package can be used to set the logging level for all
+#      packages.  Eg: root=error.
 #
 # [pam]
 #   service
@@ -24,6 +26,8 @@
 # port=5650
 
 [logging]
+# root=debug
+# gofer=debug
 # gofer.agent=debug
 # gofer.messaging=debug
 

--- a/src/gofer/agent/config.py
+++ b/src/gofer/agent/config.py
@@ -18,6 +18,8 @@ from gofer.config import Config, Graph
 from gofer.config import REQUIRED, OPTIONAL, ANY, BOOL, NUMBER, FLOAT
 
 #
+# The gofer server configuration
+#
 # [management]
 #   enabled
 #      The manager is (enabled|disabled).
@@ -27,8 +29,10 @@ from gofer.config import REQUIRED, OPTIONAL, ANY, BOOL, NUMBER, FLOAT
 #      The port number the manager listens on.
 #
 # [logging]
-#   <module>
-#      Logging level
+#   <package>
+#      Set the logging level.  Eg: gofer.agent=debug.
+#      The 'root' package can be used to set the logging level for all
+#      packages.  Eg: root=error.
 #
 # [pam]
 #   service

--- a/src/gofer/agent/main.py
+++ b/src/gofer/agent/main.py
@@ -167,11 +167,14 @@ def start_daemon(lock):
 def setup_logging():
     """
     Set logging levels based on configuration.
+    The special name of 'root' is used to specify the root logger.
     """
     cfg = AgentConfig()
     for name, level in cfg.logging:
         if not level:
             continue
+        if name.lower() == 'root':
+            name = None
         try:
             logger = logging.getLogger(name)
             level = getattr(logging, level.upper())


### PR DESCRIPTION
Support the special `root` name in `[logging]` section of the agent.conf. 