### PR TITLE
Add interpreter exit handler to abort threads.

### DIFF
--- a/src/gofer/common.py
+++ b/src/gofer/common.py
@@ -17,6 +17,7 @@ import os
 import inspect
 import errno
 import new as _new
+import atexit
 
 from copy import copy
 from threading import local as _Local
@@ -142,6 +143,16 @@ class Thread(_Thread):
         super(Thread, self).__init__(*args, **kwargs)
         setattr(self, Thread.ABORT, Event())
 
+    def start(self):
+        """
+        Start the thread.
+        """
+        def handler():
+            self.abort()
+            self.join()
+        atexit.register(handler)
+        super(Thread, self).start()
+
     @staticmethod
     def current():
         """
@@ -166,7 +177,7 @@ class Thread(_Thread):
             event = Event()
         aborted = event.isSet()
         if aborted:
-            log.info('thread:%s, ABORTED', thread.getName())
+            log.debug('thread:%s, ABORTED', thread.getName())
         return aborted
 
     def abort(self):

--- a/src/gofer/rmi/model/parent.py
+++ b/src/gofer/rmi/model/parent.py
@@ -14,10 +14,10 @@
 #
 
 from logging import getLogger
-from threading import Thread
 from time import sleep
 
 from gofer.mp import Process, Pipe
+from gofer.common import Thread
 from gofer.rmi.context import Context
 from gofer.rmi.model import protocol
 from gofer.rmi.model.child import Call as Target

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -259,6 +259,21 @@ class TestThread(TestCase):
     def test_current(self, current):
         self.assertEqual(GThread.current(), current.return_value)
 
+    @patch('gofer.common.Thread.join')
+    @patch('gofer.common.Thread.abort')
+    @patch('threading.Thread.start')
+    def test_start(self, start, abort, join):
+        def _register(handler, *args):
+            handler(*args)
+        thread = GThread()
+        with patch('atexit.register') as register:
+            register.side_effect = _register
+            thread.start()
+        start.assert_called_once_with()
+        self.assertTrue(register.called)
+        abort.assert_called_once_with()
+        join.assert_called_once_with()
+
     @patch('gofer.common.current_thread')
     def test_aborted(self, current):
         thread = GThread()


### PR DESCRIPTION
Abort all secondary threads to mitigate know bugs in python2 interpreter shutdown.  Users have reported traces in PyTrash.