### PR TITLE
Compat with python-amqp 2.1.4, Channel.wait().

### DIFF
--- a/gofer.spec
+++ b/gofer.spec
@@ -219,7 +219,7 @@ Summary: Gofer amqp messaging adapter python package
 Group: Development/Languages
 BuildRequires: python
 Requires: python-%{name} = %{version}
-Requires: python-amqp >= 1.4.5
+Requires: python-amqp >= 2.1.4
 
 %description -n python-%{name}-amqp
 Provides the gofer amqp messaging adapter package.

--- a/src/gofer/messaging/adapter/amqp/connection.py
+++ b/src/gofer/messaging/adapter/amqp/connection.py
@@ -101,6 +101,7 @@ class Connection(BaseConnection):
             userid=userid,
             password=password,
             confirm_publish=True)
+        self._impl.connect()
         log.info('opened: %s', self.url)
 
     def channel(self):

--- a/src/gofer/messaging/adapter/amqp/consumer.py
+++ b/src/gofer/messaging/adapter/amqp/consumer.py
@@ -15,6 +15,8 @@ from Queue import Empty
 from Queue import Queue as Inbox
 from logging import getLogger
 
+from amqp.spec import Basic
+
 from gofer.common import utf8
 from gofer.messaging.adapter.model import BaseReader, Message
 from gofer.messaging.adapter.amqp.connection import Connection
@@ -154,13 +156,13 @@ class Receiver(object):
         :type timeout: int
         """
         if len(channel.method_queue):
-            channel.wait()
+            channel.wait(Basic.Deliver)
             return
         epoll = select.epoll()
         epoll.register(fd, select.EPOLLIN)
         try:
             if epoll.poll(timeout):
-                channel.wait()
+                channel.wait(Basic.Deliver)
         finally:
             epoll.unregister(fd)
             epoll.close()

--- a/test/unit/messaging/adapter/amqp/test_connection.py
+++ b/test/unit/messaging/adapter/amqp/test_connection.py
@@ -66,6 +66,7 @@ class TestConnection(TestCase):
             ssl=ssl_domain.return_value,
             confirm_publish=True)
 
+        connection.return_value.connect.assert_called_once_with()
         self.assertEqual(c._impl, connection.return_value)
 
     def test_open_already(self):


### PR DESCRIPTION
Compatibility with python-amqp 2.1.4.  Main change is re: `Channel.wait()` now takes a parameter.