### PR TITLE
Fix amqp handling of: Basic.return: (312) NO_ROUTE.

### DIFF
--- a/src/gofer/messaging/adapter/amqp/reliability.py
+++ b/src/gofer/messaging/adapter/amqp/reliability.py
@@ -34,7 +34,8 @@ def reliable(fn):
                 repair()
                 return fn(messenger, *args, **kwargs)
             except ChannelError, le:
-                if le.code != 404:
+                # 312: NO_ROUTE, 404: NOT_FOUND
+                if le.reply_code not in (312, 404):
                     log.error(utf8(le))
                     repair = messenger.repair
                     sleep(DELAY)


### PR DESCRIPTION
Handling 312 (NO_ROUTE) same as 404 (NOT_FOUND).