### PR TITLE
python-future not available in el6/el7.

### DIFF
--- a/gofer.spec
+++ b/gofer.spec
@@ -15,7 +15,7 @@
 
 
 Name: gofer
-Version: 2.12
+Version: 2.12.0
 Release: 0%{?dist}
 Summary: A lightweight, extensible python agent
 Group:   Development/Languages
@@ -184,7 +184,6 @@ Summary: Gofer python lib modules
 Group: Development/Languages
 BuildRequires: python%{?p2n}-devel
 BuildRequires: python%{?p2n}-setuptools
-Requires: python%{?p2n}-future
 Requires: python%{?p2n}-six
 Requires: pam
 %if 0%{?rhel} == 5
@@ -204,6 +203,7 @@ Provides gofer python common modules.
 %files -n python%{?p2n}-%{name}
 %defattr(-,root,root,-)
 %{python2_sitelib}/%{name}/*.py*
+%{python2_sitelib}/%{name}/compat/
 %{python2_sitelib}/%{name}/agent/
 %{python2_sitelib}/%{name}/rmi/
 %{python2_sitelib}/%{name}/tools/
@@ -222,8 +222,7 @@ Provides gofer python common modules.
 Summary: Gofer python lib modules
 Group: Development/Languages
 BuildRequires: python3-devel
-BuildRequires: python3-setuptools
-Requires: python3-future
+BuildRequires: python3-setuptools`
 Requires: python3-six
 Requires: pam
 
@@ -236,6 +235,7 @@ Provides gofer python common modules.
 %defattr(-,root,root,-)
 %{python3_sitelib}/%{name}/*.py
 %{python3_sitelib}/%{name}/__pycache__/
+%{python3_sitelib}/%{name}/compat/
 %{python3_sitelib}/%{name}/agent/
 %{python3_sitelib}/%{name}/rmi/
 %{python3_sitelib}/%{name}/tools/

--- a/src/gofer/agent/config.py
+++ b/src/gofer/agent/config.py
@@ -14,7 +14,6 @@
 #
 from six import with_metaclass
 
-
 from gofer import NAME, Singleton
 from gofer.config import Config, Graph
 from gofer.config import REQUIRED, OPTIONAL, ANY, BOOL, NUMBER, FLOAT

--- a/src/gofer/agent/plugin.py
+++ b/src/gofer/agent/plugin.py
@@ -12,8 +12,6 @@
 #
 # Jeff Ortel <jortel@redhat.com>
 #
-from six import with_metaclass
-
 
 """
 Plugin classes.
@@ -25,6 +23,7 @@ import sys
 
 from logging import getLogger
 from threading import RLock
+from six import with_metaclass
 
 from gofer import Singleton, synchronized, NAME
 from gofer.agent.config import PLUGIN_SCHEMA, PLUGIN_DEFAULTS

--- a/src/gofer/agent/whiteboard.py
+++ b/src/gofer/agent/whiteboard.py
@@ -12,10 +12,9 @@
 #
 # Jeff Ortel <jortel@redhat.com>
 #
-from six import with_metaclass
-
 
 from threading import RLock
+from six import with_metaclass
 
 from gofer import Singleton, synchronized
 from gofer.compat import str

--- a/src/gofer/common.py
+++ b/src/gofer/common.py
@@ -14,23 +14,21 @@
 #
 from __future__ import absolute_import
 
-from past.builtins import basestring
-from six import PY2
-
 
 import os
 import errno
 import atexit
 
 from copy import copy
+from logging import getLogger
 from threading import local as _Local
 from threading import Thread as _Thread
 from threading import current_thread
 from threading import Event, RLock
-from logging import getLogger
+from six import PY2
 
 from . import inspection
-from .compat import str
+from .compat import str, basestring
 
 
 log = getLogger(__name__)

--- a/src/gofer/compat/__init__.py
+++ b/src/gofer/compat/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
+
+from .builtin import str, basestring

--- a/src/gofer/compat/builtin.py
+++ b/src/gofer/compat/builtin.py
@@ -12,13 +12,11 @@
 #
 # Jeff Ortel <jortel@redhat.com>
 #
-import six
+from six import PY2
 
-# json
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
-# str|unicode
-str = six.text_type
+if PY2:
+    str = unicode
+    basestring = basestring
+else:
+    basestring = str
+    str = str

--- a/src/gofer/config.py
+++ b/src/gofer/config.py
@@ -46,16 +46,13 @@ schema = (
 cfg = Config('base.conf')
 cfg.validate(schema)
 """
-from past.builtins import basestring
-
-
 import os
 import re
 
 from threading import RLock
 from io import StringIO
 
-from gofer.compat import str, json
+from gofer.compat import str, basestring, json
 
 
 # -- constants ----------------------------------------------------------------

--- a/src/gofer/inspection.py
+++ b/src/gofer/inspection.py
@@ -17,10 +17,9 @@
 Provided to support PY3/PY3 compatibility.
 """
 
-from six import PY2, get_unbound_function
-
-
 import inspect
+
+from six import PY2, get_unbound_function
 
 from gofer.compat import str
 

--- a/src/gofer/messaging/adapter/amqp/connection.py
+++ b/src/gofer/messaging/adapter/amqp/connection.py
@@ -8,12 +8,11 @@
 # NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-from six import with_metaclass
-
 
 import ssl
 
 from logging import getLogger
+from six import with_metaclass
 from socket import error as SocketError
 
 from amqp import Connection as RealConnection

--- a/src/gofer/messaging/adapter/amqp/consumer.py
+++ b/src/gofer/messaging/adapter/amqp/consumer.py
@@ -11,9 +11,8 @@
 
 import select
 
-from queue import Empty
-from queue import Queue as Inbox
 from logging import getLogger
+from six.moves.queue import Empty, Queue as Inbox
 
 from amqp.spec import Basic
 

--- a/src/gofer/messaging/adapter/proton/connection.py
+++ b/src/gofer/messaging/adapter/proton/connection.py
@@ -8,11 +8,10 @@
 # NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-from six import with_metaclass
 
-
-from uuid import uuid4
 from logging import getLogger
+from six import with_metaclass
+from uuid import uuid4
 
 from proton import ConnectionException
 from proton import SSLDomain, SSLException

--- a/src/gofer/messaging/adapter/qpid/connection.py
+++ b/src/gofer/messaging/adapter/qpid/connection.py
@@ -12,13 +12,12 @@
 #
 # Jeff Ortel <jortel@redhat.com>
 #
-from six import with_metaclass
-
 """
 Defined Qpid broker objects.
 """
 
 from logging import getLogger
+from six import with_metaclass
 
 from qpid.messaging import Connection as RealConnection
 from qpid.messaging.transports import TRANSPORTS

--- a/src/gofer/messaging/auth.py
+++ b/src/gofer/messaging/auth.py
@@ -15,13 +15,11 @@
 """
 Message authentication plumbing.
 """
-from builtins import bytes
-from six import PY3
 
-
+from base64 import b64encode, b64decode
 from hashlib import sha256
 from logging import getLogger
-from base64 import b64encode, b64decode
+from six import PY3
 
 from gofer.compat import str
 from gofer.messaging.model import Document, DocumentError
@@ -142,7 +140,7 @@ def validate(authenticator, message):
         details = str(e)
         log.info(details)
         log.debug(details, exc_info=True)
-        de = ValidationFailed(details, original)
+        de = ValidationFailed(details, document)
         raise de
 
 

--- a/src/gofer/rmi/async.py
+++ b/src/gofer/rmi/async.py
@@ -104,7 +104,7 @@ class ReplyConsumer(Consumer):
             log.exception(document)
 
 
-class AsyncReply:
+class AsyncReply(object):
     """
     Asynchronous request reply.
     :ivar sn: The request serial number.

--- a/src/gofer/rmi/policy.py
+++ b/src/gofer/rmi/policy.py
@@ -16,13 +16,10 @@
 """
 Contains request delivery policies.
 """
-
-from past.builtins import basestring
-
 from logging import getLogger
 from uuid import uuid4
 
-from gofer.compat import str
+from gofer.compat import str, basestring
 from gofer.common import Thread, Options, nvl, released
 from gofer.messaging import Document, DocumentError
 from gofer.messaging import Producer, Reader, Queue, Exchange

--- a/src/gofer/rmi/store.py
+++ b/src/gofer/rmi/store.py
@@ -19,9 +19,9 @@ Provides (local) message storage classes.
 
 import os
 
-from time import sleep, time
 from logging import getLogger
-from queue import Queue, Empty
+from six.moves.queue import Queue, Empty
+from time import sleep, time
 
 from gofer import NAME, Thread
 from gofer.common import mkdir, rmdir, unlink

--- a/src/gofer/rmi/tracker.py
+++ b/src/gofer/rmi/tracker.py
@@ -8,7 +8,6 @@
 # NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-from six import with_metaclass
 
 """
 Request tracker classes.
@@ -16,6 +15,7 @@ Request tracker classes.
 import os
 
 from threading import RLock
+from six import with_metaclass
 
 from gofer import Singleton, synchronized, NAME
 from gofer.common import mkdir

--- a/src/gofer/threadpool.py
+++ b/src/gofer/threadpool.py
@@ -17,9 +17,9 @@
 Thread Pool classes.
 """
 
-from uuid import uuid4
 from logging import getLogger
-from queue import Queue, Empty
+from six.moves.queue import Queue, Empty
+from uuid import uuid4
 
 from gofer.compat import str
 from gofer.common import Thread, released

--- a/test/functional/plugins/testplugin.py
+++ b/test/functional/plugins/testplugin.py
@@ -67,18 +67,17 @@ class TestAuthenticator(Authenticator):
 
     def sign(self, message):
         h = sha256()
-        h.update(message)
+        h.update(message.encode('utf8'))
         digest = h.hexdigest()
         # print('signed: {}'.format(digest))
         return digest
 
-    def validate(self, document, message, signature):
-        digest = self.sign(message)
-        valid = signature == digest
+    def validate(self, document, digest, signature):
+        valid = signature == self.sign(digest)
         # print('matching signatures: [{}, {}]'.format(signature, digest))
         if valid:
             return
-        raise ValidationFailed('matching signatures: [{}, {]]'.format(signature, digest))
+        raise ValidationFailed('matching signatures: [{}, {}]]'.format(signature, digest))
 
 
 if plugin.cfg.messaging.auth:

--- a/test/functional/server.py
+++ b/test/functional/server.py
@@ -62,7 +62,7 @@ class TestAuthenticator(Authenticator):
 
     def sign(self, message):
         h = sha256()
-        h.update(message)
+        h.update(message.encode())
         digest = h.hexdigest()
         # print('signed: {}'.format(digest)
         return digest

--- a/test/unit/agent/test_decorator.py
+++ b/test/unit/agent/test_decorator.py
@@ -8,8 +8,8 @@
 # NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-from six import get_unbound_function
 
+from six import get_unbound_function
 from unittest import TestCase
 
 from mock import Mock, patch

--- a/test/unit/messaging/adapter/test_model.py
+++ b/test/unit/messaging/adapter/test_model.py
@@ -14,9 +14,7 @@
 #
 from six import with_metaclass
 
-
 from unittest import TestCase
-
 from mock import patch, Mock
 
 from gofer.compat import str

--- a/test/unit/messaging/test_auth.py
+++ b/test/unit/messaging/test_auth.py
@@ -111,7 +111,9 @@ class TestValidation(TestCase):
         except ValidationFailed as e:
             self.assertEqual(e.document, _document.return_value)
 
-    def test_validate_exception(self):
+    @patch('gofer.messaging.auth.Document')
+    def test_validate_exception(self, _document):
+        _document.return_value = Document()
         message = '[]'
         reason = 'this is bad'
         authenticator = Mock()
@@ -123,7 +125,7 @@ class TestValidation(TestCase):
             self.assertTrue(False, msg='validation exception expected')
         except ValidationFailed as e:
             self.assertEqual(e.details, reason)
-            self.assertEqual(e.document, message)
+            self.assertEqual(e.document, _document.return_value)
 
     @patch('gofer.messaging.auth.Document')
     def test_no_message(self, _document):

--- a/test/unit/rmi/test_async.py
+++ b/test/unit/rmi/test_async.py
@@ -9,9 +9,12 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+from six import unichr
+
 from unittest import TestCase
 from mock import Mock
 
+from gofer.compat import str
 from gofer.messaging import Document
 from gofer.rmi.async import (
     AsyncReply,
@@ -59,10 +62,10 @@ class TestAsyncReply(TestCase):
         self.assertEqual(reply.timestamp, document.timestamp)
         self.assertEqual(reply.data, document.data)
 
-    def test_unicode(self):
+    def test_str(self):
         reply = AsyncReply(document)
-        s = unicode(reply)
-        self.assertTrue(isinstance(s, unicode))
+        s = str(reply)
+        self.assertTrue(isinstance(s, str))
 
 
 class TestAccepted(TestCase):
@@ -83,10 +86,10 @@ class TestAccepted(TestCase):
         reply.notify(f)
         f.assert_called_once_with(reply)
 
-    def test_unicode(self):
+    def test_str(self):
         reply = Accepted(document)
-        s = unicode(reply)
-        self.assertTrue(isinstance(s, unicode))
+        s = str(reply)
+        self.assertTrue(isinstance(s, str))
 
 
 class TestRejected(TestCase):
@@ -107,10 +110,10 @@ class TestRejected(TestCase):
         reply.notify(f)
         f.assert_called_once_with(reply)
 
-    def test_unicode(self):
+    def test_str(self):
         reply = Rejected(document)
-        s = unicode(reply)
-        self.assertTrue(isinstance(s, unicode))
+        s = str(reply)
+        self.assertTrue(isinstance(s, str))
 
 
 class TestStarted(TestCase):
@@ -131,10 +134,10 @@ class TestStarted(TestCase):
         reply.notify(f)
         f.assert_called_once_with(reply)
 
-    def test_unicode(self):
+    def test_str(self):
         reply = Started(document)
-        s = unicode(reply)
-        self.assertTrue(isinstance(s, unicode))
+        s = str(reply)
+        self.assertTrue(isinstance(s, str))
 
 
 class TestProgress(TestCase):
@@ -158,10 +161,10 @@ class TestProgress(TestCase):
         reply.notify(f)
         f.assert_called_once_with(reply)
 
-    def test_unicode(self):
+    def test_str(self):
         reply = Progress(document)
-        s = unicode(reply)
-        self.assertTrue(isinstance(s, unicode))
+        s = str(reply)
+        self.assertTrue(isinstance(s, str))
 
 
 class TestFinalReply(TestCase):
@@ -196,10 +199,10 @@ class TestSucceeded(TestCase):
         reply.notify(f)
         f.assert_called_once_with(reply)
 
-    def test_unicode(self):
+    def test_str(self):
         reply = Succeeded(document)
-        s = unicode(reply)
-        self.assertTrue(isinstance(s, unicode))
+        s = str(reply)
+        self.assertTrue(isinstance(s, str))
 
 
 class TestFailed(TestCase):
@@ -229,7 +232,7 @@ class TestFailed(TestCase):
         except ValueError:
             pass
 
-    def test_unicode(self):
+    def test_str(self):
         reply = Failed(document)
-        s = unicode(reply)
-        self.assertTrue(isinstance(s, unicode))
+        s = str(reply)
+        self.assertTrue(isinstance(s, str))

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -8,14 +8,13 @@
 # NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-from six import with_metaclass, unichr
-
 
 import os
 import errno
 
+from six import with_metaclass, unichr
+from six.moves.queue import Queue
 from threading import Thread, Event
-from queue import Queue
 
 from unittest import TestCase
 


### PR DESCRIPTION
python-future is a great compat lib not available in el6/el7.

Fixed exception propagation of builtin exceptions when raised by different python versions (2/3).

Fixed raising `ValidationError` when non-validation related exceptions are caught.

Changed gofer.compat to be a package.

Z-bit added to version: 2.12.0