### PR TITLE
Adapter reliability logging at WARN instead of ERROR.

### DIFF
--- a/src/gofer/messaging/adapter/amqp/reliability.py
+++ b/src/gofer/messaging/adapter/amqp/reliability.py
@@ -40,13 +40,13 @@ def reliable(fn):
                 return fn(messenger, *args, **kwargs)
             except ChannelError as le:
                 if le.reply_code not in (NO_ROUTE, NOT_FOUND):
-                    log.error(str(le))
+                    log.warn(str(le))
                     repair = messenger.repair
                     sleep(DELAY)
                 else:
                     raise NotFound(*le.args)
             except CONNECTION_EXCEPTIONS as pe:
-                log.error(str(pe))
+                log.warn(str(pe))
                 repair = messenger.repair
                 sleep(DELAY)
     return _fn

--- a/src/gofer/messaging/adapter/proton/reliability.py
+++ b/src/gofer/messaging/adapter/proton/reliability.py
@@ -45,13 +45,13 @@ def reliable(fn):
                 return fn(messenger, *args, **kwargs)
             except LinkDetached as le:
                 if le.condition != NOT_FOUND:
-                    log.error(str(le))
+                    log.warn(str(le))
                     repair = messenger.repair
                     sleep(DELAY)
                 else:
                     raise NotFound(*le.args)
             except ConnectionException as pe:
-                log.error(str(pe))
+                log.warn(str(pe))
                 repair = messenger.repair
                 sleep(DELAY)
     return _fn

--- a/src/gofer/messaging/adapter/qpid/reliability.py
+++ b/src/gofer/messaging/adapter/qpid/reliability.py
@@ -38,11 +38,11 @@ def reliable(fn):
             except _NotFound as e:
                 raise NotFound(*e.args)
             except LinkError as le:
-                log.error(str(le))
+                log.warn(str(le))
                 repair = thing.repair
                 sleep(DELAY)
             except ConnectionError as pe:
-                log.error(str(pe))
+                log.warn(str(pe))
                 repair = thing.repair
                 sleep(DELAY)
     return _fn


### PR DESCRIPTION
Fixes #91

Updated the _reliability_ modules to log link an connection errors at WARN instead of ERROR.  Requested by Katello bugzilla[1].

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1608217