### PR TITLE
[2.11] Consumer read: log node-not-found at debug instead of error.

### DIFF
--- a/src/gofer/messaging/consumer.py
+++ b/src/gofer/messaging/consumer.py
@@ -104,7 +104,7 @@ class ConsumerThread(Thread):
         except DocumentError, de:
             self.rejected(de.code, de.description, de.document, de.details)
         except NotFound, le:
-            log.error(utf8(le))
+            log.debug(utf8(le))
             sleep(10)
             self.repair()
         except Exception:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1417345