### PR TITLE
[2.12] Consumer read: log node-not-found at debug instead of error.

### DIFF
--- a/src/gofer/messaging/consumer.py
+++ b/src/gofer/messaging/consumer.py
@@ -105,7 +105,7 @@ class ConsumerThread(Thread):
         except DocumentError as de:
             self.rejected(de.code, de.description, de.document, de.details)
         except NotFound as le:
-            log.error(str(le))
+            log.debug(str(le))
             sleep(10)
             self.repair()
         except Exception:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1417345