### PR TITLE
Consumer read call no_route instead of repair on node not-found.

### DIFF
--- a/src/gofer/messaging/consumer.py
+++ b/src/gofer/messaging/consumer.py
@@ -106,7 +106,7 @@ class ConsumerThread(Thread):
         except NotFound, le:
             log.debug(utf8(le))
             sleep(10)
-            self.repair()
+            self.no_route()
         except Exception:
             log.exception(self.getName())
             sleep(30)


### PR DESCRIPTION
In Consumer read(), no_route() needs to be called instead of repair when the queue is deleted while the consumer is attached.